### PR TITLE
Add screenshot diagnostics and image attachment fallback

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -28,8 +28,12 @@ class FloatingPanel: NSPanel {
         contentView = hostingView
 
         // Wire up the submit callback
-        searchViewModel.onSubmit = { [weak self] context in
-            self?.transitionToTerminal(message: context)
+        searchViewModel.onSubmit = { [weak self] context, screenshotURL, screenshotStatus in
+            self?.transitionToTerminal(
+                message: context,
+                screenshotURL: screenshotURL,
+                screenshotStatus: screenshotStatus
+            )
         }
         searchViewModel.onClose = { [weak self] in
             self?.close()
@@ -94,7 +98,11 @@ class FloatingPanel: NSPanel {
         }
     }
 
-    func transitionToTerminal(message: String) {
+    func transitionToTerminal(
+        message: String,
+        screenshotURL: URL? = nil,
+        screenshotStatus: String? = nil
+    ) {
         isTerminalMode = true
         removeAllMonitors()
 
@@ -111,12 +119,15 @@ class FloatingPanel: NSPanel {
             if let sid = manager.sessionId {
                 self?.searchViewModel.currentSessionId = sid
             }
-            self?.searchViewModel.claudeManager = nil
         }
         searchViewModel.claudeManager = manager
         searchViewModel.isChatMode = true
 
-        manager.start(message: message)
+        manager.start(
+            message: message,
+            screenshotURL: screenshotURL,
+            screenshotDebug: screenshotStatus
+        )
     }
 
     private func positionAtCursor() {
@@ -163,7 +174,6 @@ class FloatingPanel: NSPanel {
         if let manager = searchViewModel.claudeManager,
            manager.status == .waiting || manager.status == .streaming {
             manager.stop()
-            searchViewModel.claudeManager = nil
         } else {
             close()
         }

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -10,10 +10,12 @@ class SearchViewModel: ObservableObject {
     @Published var isChatMode = false
     @Published var claudeManager: ClaudeProcessManager?
     @Published var chatHistory: [(role: String, text: String)] = []
+    @Published var lastScreenshotStatus: String = ""
     var currentSessionId: String?
+    private var hoveredAppPID: pid_t = 0
 
     /// Set by FloatingPanel
-    var onSubmit: ((String) -> Void)?
+    var onSubmit: ((String, URL?, String) -> Void)?
     var onClose: (() -> Void)?
 
     func submitMessage() {
@@ -39,7 +41,9 @@ class SearchViewModel: ObservableObject {
         } else {
             // First message — switch to chat mode
             let context = buildContextMessage()
-            onSubmit?(context)
+            let (screenshotURL, screenshotStatus) = captureHoveredWindowScreenshot()
+            lastScreenshotStatus = screenshotStatus
+            onSubmit?(context, screenshotURL, screenshotStatus)
         }
     }
 
@@ -82,6 +86,59 @@ class SearchViewModel: ObservableObject {
         return lines.joined(separator: "\n")
     }
 
+    func captureHoveredWindowScreenshot() -> (URL?, String) {
+        guard hoveredAppPID != 0 else {
+            return (nil, "Screenshot not captured: no hovered app")
+        }
+
+        guard CGPreflightScreenCaptureAccess() else {
+            CGRequestScreenCaptureAccess()
+            return (nil, "Screenshot not captured: screen recording permission not granted")
+        }
+
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return (nil, "Screenshot not captured: failed to enumerate windows")
+        }
+
+        let appWindows = windowList.filter {
+            ($0[kCGWindowOwnerPID as String] as? pid_t) == hoveredAppPID
+        }
+
+        let sortedWindows = appWindows.sorted {
+            ($0[kCGWindowLayer as String] as? Int ?? 999) < ($1[kCGWindowLayer as String] as? Int ?? 999)
+        }
+
+        guard let topWindow = sortedWindows.first,
+              let windowID = topWindow[kCGWindowNumber as String] as? CGWindowID else {
+            return (nil, "Screenshot not captured: no visible window for hovered app")
+        }
+
+        guard let cgImage = CGWindowListCreateImage(
+            .null, .optionIncludingWindow, windowID, [.boundsIgnoreFraming]
+        ) else {
+            return (nil, "Screenshot not captured: CGWindowListCreateImage failed")
+        }
+
+        let nsImage = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        guard let tiffData = nsImage.tiffRepresentation,
+              let bitmapRep = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmapRep.representation(using: .png, properties: [:]) else {
+            return (nil, "Screenshot not captured: failed to encode PNG data")
+        }
+
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hp_screenshot_\(UUID().uuidString).png")
+        do {
+            try pngData.write(to: tempURL)
+            let kb = max(1, pngData.count / 1024)
+            return (tempURL, "Screenshot captured: \(cgImage.width)x\(cgImage.height), \(kb) KB")
+        } catch {
+            return (nil, "Screenshot not captured: failed to write temp file (\(error.localizedDescription))")
+        }
+    }
+
     func updateHoveredApp() {
         let mouseLocation = NSEvent.mouseLocation
         guard let screen = NSScreen.main else { return }
@@ -95,6 +152,13 @@ class SearchViewModel: ObservableObject {
         guard result == .success, let element = element else {
             hoveredApp = ""
             return
+        }
+
+        // Store the PID of the hovered app for screenshot use
+        var pid: pid_t = 0
+        AXUIElementGetPid(element, &pid)
+        if let app = NSRunningApplication(processIdentifier: pid), app.localizedName != "HyperPointer" {
+            hoveredAppPID = pid
         }
 
         // Build a description from the element hierarchy

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -33,6 +33,7 @@ class ClaudeProcessManager: ObservableObject {
     @Published var outputText = ""
     @Published var status: StreamStatus = .waiting
     @Published var events: [StreamEvent] = []
+    @Published var diagnostics: [String] = []
     var onComplete: ((String) -> Void)?
     var sessionId: String?
 
@@ -40,13 +41,60 @@ class ClaudeProcessManager: ObservableObject {
     private var buffer = Data()
     private let queue = DispatchQueue(label: "claude-stream", qos: .userInitiated)
     private var isStopped = false
+    private var jsonLineCount = 0
+    private var nonJSONLineCount = 0
+    private var stderrLineCount = 0
+    private var nonJSONPreviewCount = 0
+    private var runStartedAt: Date?
+    private var cachedImageFlagSupport: Bool?
+    private let maxDiagnostics = 80
 
-    func start(message: String, resumeSessionId: String? = nil) {
+    func start(
+        message: String,
+        screenshotURL: URL? = nil,
+        resumeSessionId: String? = nil,
+        screenshotDebug: String? = nil
+    ) {
         // Reset stale events from previous messages
-        DispatchQueue.main.async { self.events = [] }
+        DispatchQueue.main.async {
+            self.events = []
+            self.outputText = ""
+            self.status = .waiting
+            self.diagnostics = []
+        }
+        isStopped = false
+        accumulated = ""
+        buffer = Data()
+        jsonLineCount = 0
+        nonJSONLineCount = 0
+        stderrLineCount = 0
+        nonJSONPreviewCount = 0
+        runStartedAt = Date()
+
         guard let claudePath = resolveClaudePath() else {
             status = .error("Could not find 'claude' binary")
             return
+        }
+        addDiagnostic("Claude binary: \(claudePath)")
+        if let sid = resumeSessionId {
+            addDiagnostic("Session mode: resume \(sid)")
+        } else {
+            addDiagnostic("Session mode: new")
+        }
+        if let screenshotDebug, !screenshotDebug.isEmpty {
+            addDiagnostic(screenshotDebug)
+        } else if screenshotURL == nil {
+            addDiagnostic("Screenshot not requested for this message")
+        }
+
+        let effectiveScreenshotURL = normalizedScreenshotURL(
+            screenshotURL,
+            claudePath: claudePath
+        )
+        if effectiveScreenshotURL != nil {
+            addDiagnostic("Image attachment enabled")
+        } else if screenshotURL != nil {
+            addDiagnostic("Image attachment skipped")
         }
 
         let process = Process()
@@ -54,10 +102,11 @@ class ClaudeProcessManager: ObservableObject {
 
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
         var claudeCmd: String
+        let imageFlag = effectiveScreenshotURL != nil ? "--image \"$HP_SCREENSHOT\" " : ""
         if let sid = resumeSessionId {
-            claudeCmd = "\(claudePath) --print --resume \(sid) -p \"$HP_MESSAGE\" --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
+            claudeCmd = "\(claudePath) --print --resume \(sid) -p \"$HP_MESSAGE\" \(imageFlag)--output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
         } else {
-            claudeCmd = "\(claudePath) --print -p \"$HP_MESSAGE\" --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
+            claudeCmd = "\(claudePath) --print -p \"$HP_MESSAGE\" \(imageFlag)--output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
         }
         process.arguments = ["-l", "-c", claudeCmd]
         process.standardInput = FileHandle.nullDevice
@@ -71,6 +120,9 @@ class ClaudeProcessManager: ObservableObject {
         let currentPath = env["PATH"] ?? "/usr/bin:/bin"
         env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
         env["HP_MESSAGE"] = message
+        if let screenshotURL = effectiveScreenshotURL {
+            env["HP_SCREENSHOT"] = screenshotURL.path
+        }
         process.environment = env
 
         let stdout = Pipe()
@@ -96,6 +148,10 @@ class ClaudeProcessManager: ObservableObject {
                 if data.isEmpty { break }
                 if let text = String(data: data, encoding: .utf8) {
                     DispatchQueue.main.async {
+                        self?.stderrLineCount += text.split(whereSeparator: \.isNewline).count
+                        if let firstLine = text.split(whereSeparator: \.isNewline).first {
+                            self?.addDiagnostic("stderr: \(String(firstLine).trimmingCharacters(in: .whitespacesAndNewlines))")
+                        }
                         self?.outputText += "[STDERR] \(text)\n"
                         if case .waiting = self?.status { self?.status = .streaming }
                     }
@@ -104,8 +160,23 @@ class ClaudeProcessManager: ObservableObject {
         }
 
         process.terminationHandler = { [weak self] proc in
+            // Clean up screenshot temp file
+            if let screenshotURL = effectiveScreenshotURL {
+                try? FileManager.default.removeItem(at: screenshotURL)
+            }
             DispatchQueue.main.async {
                 guard let self = self else { return }
+                let seconds = self.runStartedAt.map { Date().timeIntervalSince($0) } ?? 0
+                self.addDiagnostic(
+                    String(
+                        format: "Process exit: %d (%.1fs), JSON lines: %d, non-JSON lines: %d, stderr lines: %d",
+                        proc.terminationStatus,
+                        seconds,
+                        self.jsonLineCount,
+                        self.nonJSONLineCount,
+                        self.stderrLineCount
+                    )
+                )
                 if case .error = self.status { return }
                 if self.isStopped || proc.terminationStatus == 0 {
                     self.status = .done
@@ -118,10 +189,57 @@ class ClaudeProcessManager: ObservableObject {
 
         do {
             try process.run()
+            addDiagnostic("Process started (pid: \(process.processIdentifier))")
         } catch {
             status = .error("Failed to launch: \(error.localizedDescription)")
             return
         }
+    }
+
+    private func normalizedScreenshotURL(_ screenshotURL: URL?, claudePath: String) -> URL? {
+        guard let screenshotURL = screenshotURL else { return nil }
+        if FileManager.default.fileExists(atPath: screenshotURL.path),
+           let attrs = try? FileManager.default.attributesOfItem(atPath: screenshotURL.path),
+           let bytes = attrs[.size] as? NSNumber {
+            let kb = max(1, bytes.intValue / 1024)
+            addDiagnostic("Screenshot temp file: \(screenshotURL.lastPathComponent) (\(kb) KB)")
+        } else {
+            addDiagnostic("Screenshot temp file missing: \(screenshotURL.lastPathComponent)")
+        }
+
+        guard supportsImageFlag(claudePath: claudePath) else {
+            // Avoid leaking temp files when this CLI doesn't support image attachments.
+            try? FileManager.default.removeItem(at: screenshotURL)
+            addDiagnostic("CLI does not support --image; temp file removed")
+            return nil
+        }
+        return screenshotURL
+    }
+
+    private func supportsImageFlag(claudePath: String) -> Bool {
+        if let cached = cachedImageFlagSupport {
+            return cached
+        }
+        let help = Process()
+        help.executableURL = URL(fileURLWithPath: claudePath)
+        help.arguments = ["--help"]
+        let pipe = Pipe()
+        help.standardOutput = pipe
+        help.standardError = pipe
+        do {
+            try help.run()
+            help.waitUntilExit()
+        } catch {
+            cachedImageFlagSupport = false
+            return false
+        }
+        guard let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) else {
+            cachedImageFlagSupport = false
+            return false
+        }
+        let supported = output.contains("--image")
+        cachedImageFlagSupport = supported
+        return supported
     }
 
     private func handleData(_ data: Data) {
@@ -135,6 +253,17 @@ class ClaudeProcessManager: ObservableObject {
             guard let line = String(data: lineData, encoding: .utf8),
                   !line.trimmingCharacters(in: .whitespaces).isEmpty else {
                 continue
+            }
+
+            if isJSONObject(line) {
+                jsonLineCount += 1
+            } else {
+                nonJSONLineCount += 1
+                if nonJSONPreviewCount < 8 {
+                    let preview = String(line.prefix(200))
+                    addDiagnostic("Non-JSON output: \(preview)")
+                    nonJSONPreviewCount += 1
+                }
             }
 
             let text = extractText(from: line)
@@ -232,6 +361,23 @@ class ClaudeProcessManager: ObservableObject {
         }
 
         return nil
+    }
+
+    private func isJSONObject(_ line: String) -> Bool {
+        guard let data = line.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) else {
+            return false
+        }
+        return json is [String: Any]
+    }
+
+    private func addDiagnostic(_ line: String) {
+        DispatchQueue.main.async {
+            self.diagnostics.append(line)
+            if self.diagnostics.count > self.maxDiagnostics {
+                self.diagnostics.removeFirst(self.diagnostics.count - self.maxDiagnostics)
+            }
+        }
     }
 
     private func resolveClaudePath() -> String? {
@@ -518,6 +664,43 @@ struct EventsSummaryView: View {
     }
 }
 
+struct DiagnosticsView: View {
+    let lines: [String]
+    let isLive: Bool
+    @State private var isExpanded = true
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button(action: { withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() } }) {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+
+                    Image(systemName: "ladybug")
+                        .font(.system(size: 10))
+                        .foregroundColor(.secondary)
+
+                    Text(isLive ? "Run diagnostics (live)" : "Run diagnostics")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                    Text(line)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
 // MARK: - Panel Content View (switches between search and chat)
 
 struct PanelContentView: View {
@@ -582,6 +765,14 @@ struct ChatView: View {
                         }
 
                         if let manager = viewModel.claudeManager,
+                           !manager.diagnostics.isEmpty {
+                            DiagnosticsView(
+                                lines: manager.diagnostics,
+                                isLive: manager.status == .waiting || manager.status == .streaming
+                            )
+                        }
+
+                        if let manager = viewModel.claudeManager,
                            manager.status == .waiting || manager.status == .streaming {
                             StreamingTimerView()
                         }
@@ -623,7 +814,6 @@ struct ChatView: View {
                    manager.status == .waiting || manager.status == .streaming {
                     Button(action: {
                         manager.stop()
-                        viewModel.claudeManager = nil
                     }) {
                         Image(systemName: "stop.fill")
                             .font(.system(size: 10))


### PR DESCRIPTION
This adds first-message screenshot capture wiring into the Claude process launch path and records explicit capture outcomes (success, permission, window lookup, encoding, and temp-file write failures). It adds run diagnostics in the chat UI so each request shows whether image attachment was enabled or skipped, plus stderr/non-JSON previews and process-exit stats for debugging hangs. It also adds CLI capability detection for `--image` and automatically falls back to text-only when unsupported, cleaning up temporary screenshot files. Finally, stop behavior now preserves the completed run state so diagnostics remain visible after cancellation.