### PR TITLE
Render markdown in Claude output

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "networkimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "state" : {
+        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown-ui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "state" : {
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,15 @@ import PackageDescription
 let package = Package(
     name: "HyperPointer",
     platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.0.2"),
+    ],
     targets: [
         .executableTarget(
             name: "HyperPointer",
+            dependencies: [
+                .product(name: "MarkdownUI", package: "swift-markdown-ui"),
+            ],
             path: "Sources"
         )
     ]

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import Combine
+import MarkdownUI
 
 // MARK: - Stream Event Models
 
@@ -715,6 +716,64 @@ struct PanelContentView: View {
     }
 }
 
+// MARK: - Markdown message renderer
+
+private extension Theme {
+    static let assistant = Theme()
+        .text {
+            ForegroundColor(.primary)
+            FontSize(13)
+        }
+        .strong {
+            FontWeight(.semibold)
+        }
+        .emphasis {
+            FontStyle(.italic)
+        }
+        .code {
+            FontFamilyVariant(.monospaced)
+            FontSize(.em(0.9))
+        }
+        .heading1 { configuration in
+            configuration.label.markdownTextStyle {
+                FontWeight(.bold)
+                FontSize(.em(1.1))
+            }
+        }
+        .heading2 { configuration in
+            configuration.label.markdownTextStyle {
+                FontWeight(.semibold)
+                FontSize(.em(1.05))
+            }
+        }
+        .heading3 { configuration in
+            configuration.label.markdownTextStyle {
+                FontWeight(.semibold)
+            }
+        }
+        .codeBlock { configuration in
+            configuration.label
+                .relativeLineSpacing(.em(0.25))
+                .markdownTextStyle {
+                    FontFamilyVariant(.monospaced)
+                    FontSize(.em(0.9))
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(Color.primary.opacity(0.06))
+                .cornerRadius(6)
+        }
+}
+
+private struct AssistantMarkdown: View {
+    let text: String
+    var body: some View {
+        Markdown(text)
+            .markdownTheme(.assistant)
+            .textSelection(.enabled)
+    }
+}
+
 // MARK: - Chat View (output + input in the floating panel)
 
 struct ChatView: View {
@@ -754,9 +813,7 @@ struct ChatView: View {
                                     .font(.system(size: 12, design: .monospaced))
                                     .foregroundColor(.secondary)
                             } else {
-                                Text(entry.text)
-                                    .font(.system(size: 13))
-                                    .textSelection(.enabled)
+                                AssistantMarkdown(text: entry.text)
                             }
                         }
 
@@ -780,9 +837,7 @@ struct ChatView: View {
                         if let manager = viewModel.claudeManager,
                            !manager.outputText.isEmpty,
                            manager.status == .done {
-                            Text(manager.outputText)
-                                .font(.system(size: 13))
-                                .textSelection(.enabled)
+                            AssistantMarkdown(text: manager.outputText)
                         }
 
                         Spacer().frame(height: 0).id("bottom")


### PR DESCRIPTION
## Summary
- Add `swift-markdown-ui` 2.4.1 dependency for full markdown rendering support
- Implement custom `.assistant` theme that preserves 13pt SF Pro styling while rendering markdown formatting
- Replace plain `Text` views with `MarkdownUI.Markdown` component for both chat history and current responses

## Features
Markdown now renders properly with **bold**, *italic*, `code`, headings, lists, tables, and code blocks—without changing the original visual appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)