### PR TITLE
Improve object detection specificity to match right-click precision

### DIFF
--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -218,7 +218,8 @@ class SearchViewModel: ObservableObject {
         "AXRadioButton", "AXSlider", "AXPopUpButton", "AXComboBox",
         "AXMenuItem", "AXMenuBarItem", "AXTab", "AXCell", "AXRow",
         "AXHeading", "AXDockItem", "AXDisclosureTriangle",
-        "AXColorWell", "AXIncrementor"
+        "AXColorWell", "AXIncrementor",
+        "AXStaticText", "AXImage"
     ]
 
     // Container roles — good as ancestor context but too broad as primary
@@ -234,7 +235,8 @@ class SearchViewModel: ObservableObject {
             "AXMenuItem", "AXMenuBarItem", "AXTab", "AXCell", "AXRow",
             "AXHeading", "AXDockItem", "AXDisclosureTriangle",
             "AXColorWell", "AXIncrementor",
-            "AXList", "AXTable", "AXOutline", "AXToolbar", "AXTabGroup"
+            "AXList", "AXTable", "AXOutline", "AXToolbar", "AXTabGroup",
+            "AXStaticText", "AXImage"
         ]
         return s
     }()
@@ -245,6 +247,12 @@ class SearchViewModel: ObservableObject {
 
         // If the leaf is already a primary interactive element, use it
         if primaryRoles.contains(leafRole) {
+            return (element, collectAncestors(above: element))
+        }
+
+        // If the leaf has selected text, use it directly — like right-click on a selection
+        let leafSel = axValue(element, key: kAXSelectedTextAttribute) as? String ?? ""
+        if !leafSel.isEmpty {
             return (element, collectAncestors(above: element))
         }
 
@@ -329,7 +337,19 @@ class SearchViewModel: ObservableObject {
         let value = axValue(primary, key: kAXValueAttribute) as? String ?? ""
 
         let readableRole = humanRole(role, subrole: subrole, roleDesc: roleDesc)
-        let elementName = firstNonEmpty(title, desc, truncated(value, max: 40))
+
+        // For static text, prefer value (the text content itself) over title/desc
+        let elementName: String
+        if role == "AXStaticText" {
+            let textContent = firstNonEmpty(value, title, desc)
+            elementName = truncated(textContent, max: 60)
+        } else {
+            elementName = firstNonEmpty(title, desc, truncated(value, max: 40))
+        }
+
+        // Check if the primary element has selected text — treat it as "selected text" context
+        let primarySel = axValue(primary, key: kAXSelectedTextAttribute) as? String ?? ""
+        let hasSelection = !primarySel.isEmpty
 
         var parts: [String] = []
 
@@ -356,7 +376,9 @@ class SearchViewModel: ObservableObject {
             let webInfo = webElementInfo(primary)
             if !webInfo.isEmpty { parts.append(contentsOf: webInfo) }
 
-            if !elementName.isEmpty {
+            if hasSelection {
+                parts.append("selected text: \(truncated(primarySel, max: 60))")
+            } else if !elementName.isEmpty {
                 parts.append("\(readableRole): \(elementName)")
             } else if !readableRole.isEmpty && readableRole != "web content" {
                 parts.append(readableRole)
@@ -376,7 +398,9 @@ class SearchViewModel: ObservableObject {
                 }
             }
 
-            if !elementName.isEmpty {
+            if hasSelection {
+                parts.append("selected text: \(truncated(primarySel, max: 60))")
+            } else if !elementName.isEmpty {
                 parts.append("\(readableRole): \(elementName)")
             } else if !readableRole.isEmpty {
                 parts.append(readableRole)
@@ -488,9 +512,11 @@ class SearchViewModel: ObservableObject {
             "AXWindow": "window",
             "AXSheet": "sheet",
             "AXDialog": "dialog",
+            "AXPanel": "panel",
             "AXMenuBar": "menu bar",
             "AXMenuBarItem": "menu",
             "AXMenuItem": "menu item",
+            "AXMenuButton": "menu button",
             "AXMenu": "menu",
             "AXDockItem": "dock item",
             "AXWebArea": "web content",


### PR DESCRIPTION
## Summary

Enhance HyperPointer's object detection to identify UI elements with the same granularity as macOS right-click context menus.

- **Add static text and images as primary elements**: Previously, hovering over text labels or images would walk up to a container. Now they're recognized directly.
- **Prioritize selected text**: When text is selected, the selection context is preserved rather than escalating to a parent container, matching right-click behavior.
- **Improved text element handling**: Static text elements now display their actual text content instead of generic role descriptions.
- **Better menu element support**: Added panel and menu button role mappings for cleaner element descriptions across all UI contexts.

This brings detection granularity to the exact element level—whether it's highlighted text, a button, an image, a menu item, or a specific panel—just like right-click context menus do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)