### PR TITLE
Require Command + right click to activate panel

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -24,6 +24,11 @@ private func rightClickCallback(
         return Unmanaged.passRetained(event)
     }
 
+    // Only activate on Command + right click; let plain right clicks through
+    guard event.flags.contains(.maskCommand) else {
+        return Unmanaged.passRetained(event)
+    }
+
     // Convert CG coordinates (top-left origin) to NS coordinates (bottom-left origin)
     let cgLocation = event.location
     if let screen = NSScreen.main {


### PR DESCRIPTION
## Summary
Right-click now requires the Command modifier to activate the panel. Regular right-clicks pass through as normal context menus.

## Changes
- Modified `rightClickCallback` in AppDelegate to check `event.flags.contains(.maskCommand)`
- Only intercepts right mouse down when Command is held
- Allows native context menus to work on plain right-click

🤖 Generated with Claude Code