### PR TITLE
Hold ⌘ to activate panel with visual indicator

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -49,6 +49,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var panels: [FloatingPanel] = []
     var hotKeyMonitor: Any?
     fileprivate var eventTap: CFMachPort?
+    private var flagsMonitor: Any?
+    private var localFlagsMonitor: Any?
+    private var commandKeyHeld = false
+    private weak var commandKeyPanel: FloatingPanel?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         sharedAppDelegate = self
@@ -69,6 +73,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 return nil
             }
             return event
+        }
+
+        // Hold ⌘ to activate panel; release before sending = dismiss, release after = keep
+        flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlagsChanged(event)
+        }
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlagsChanged(event)
+            return event
+        }
+    }
+
+    private func handleFlagsChanged(_ event: NSEvent) {
+        let commandDown = event.modifierFlags.contains(.command)
+        if commandDown && !commandKeyHeld {
+            commandKeyHeld = true
+
+            // Reuse an existing visible non-chat panel if one exists
+            if let existing = panels.first(where: {
+                $0.isVisible && !$0.searchViewModel.isChatMode
+            }) {
+                commandKeyPanel = existing
+                existing.isCommandKeyHeld = true
+                existing.restartCommandKeyMode()
+            } else {
+                panels.removeAll { !$0.isVisible }
+                let panel = FloatingPanel()
+                commandKeyPanel = panel
+                panels.append(panel)
+                panel.startCommandKeyMode()
+            }
+        } else if !commandDown && commandKeyHeld {
+            commandKeyHeld = false
+            if let panel = commandKeyPanel {
+                panel.isCommandKeyHeld = false
+                panel.endCommandKeyMode()
+            }
+            commandKeyPanel = nil
         }
     }
 

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -6,8 +6,11 @@ class FloatingPanel: NSPanel {
     private var globalMouseMonitor: Any?
     private var localMouseMonitor: Any?
     private var globalClickMonitor: Any?
+    private var commandKeyMouseMonitor: Any?
     private var hostingView: NSHostingView<PanelContentView>!
     private var isTerminalMode = false
+    private var isCommandKeyVisible = false
+    var isCommandKeyHeld = false
 
     init() {
         super.init(
@@ -149,13 +152,97 @@ class FloatingPanel: NSPanel {
         }
     }
 
+    // MARK: - Command key mode
+
+    /// Called when ⌘ is pressed. Shows a minimal icon indicator immediately,
+    /// then expands to the full panel on the first cursor move.
+    func startCommandKeyMode() {
+        searchViewModel.isCommandKeyMode = true
+        searchViewModel.isMinimalMode = true
+        searchViewModel.query = ""
+        isCommandKeyVisible = false
+
+        // Show the indicator right away at the current cursor position
+        searchViewModel.updateHoveredApp()
+        positionAtCursor()
+        orderFront(nil)
+
+        commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            guard let self else { return }
+            if !self.isCommandKeyVisible {
+                self.isCommandKeyVisible = true
+                self.searchViewModel.isMinimalMode = false
+            }
+            self.positionAtCursor()
+            self.searchViewModel.updateHoveredApp()
+        }
+    }
+
+    /// Called when ⌘ is released. Anchors the panel and shows the input row.
+    /// If the panel was never shown (cursor didn't move), discard silently.
+    func endCommandKeyMode() {
+        if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
+        if let m = globalMouseMonitor { NSEvent.removeMonitor(m); globalMouseMonitor = nil }
+        if let m = localMouseMonitor { NSEvent.removeMonitor(m); localMouseMonitor = nil }
+
+        guard isCommandKeyVisible else {
+            close()
+            return
+        }
+
+        // Show input row if it was hidden
+        if searchViewModel.isCommandKeyMode {
+            searchViewModel.isCommandKeyMode = false
+            makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        // Dismiss when cursor moves (unless ⌘ is held again or a message was sent)
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            guard let self, !self.isCommandKeyHeld, !self.searchViewModel.isChatMode else { return }
+            self.close()
+        }
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            guard let self, !self.isCommandKeyHeld, !self.searchViewModel.isChatMode else { return event }
+            self.close()
+            return event
+        }
+    }
+
+    /// Re-enter cursor-following on an already-visible panel.
+    /// Hides the input row only if no text has been typed yet.
+    func restartCommandKeyMode() {
+        if let m = globalMouseMonitor { NSEvent.removeMonitor(m); globalMouseMonitor = nil }
+        if let m = localMouseMonitor { NSEvent.removeMonitor(m); localMouseMonitor = nil }
+        if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
+
+        isCommandKeyVisible = true
+        if searchViewModel.query.isEmpty {
+            searchViewModel.isCommandKeyMode = true
+        }
+
+        // Global monitor fires when another app is frontmost; local monitor fires when we are.
+        commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
+            guard let self else { return }
+            self.positionAtCursor()
+            self.searchViewModel.updateHoveredApp()
+        }
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            guard let self else { return event }
+            self.positionAtCursor()
+            self.searchViewModel.updateHoveredApp()
+            return event
+        }
+    }
+
     private func removeAllMonitors() {
-        for monitor in [globalMouseMonitor, localMouseMonitor, globalClickMonitor].compactMap({ $0 }) {
+        for monitor in [globalMouseMonitor, localMouseMonitor, globalClickMonitor, commandKeyMouseMonitor].compactMap({ $0 }) {
             NSEvent.removeMonitor(monitor)
         }
         globalMouseMonitor = nil
         localMouseMonitor = nil
         globalClickMonitor = nil
+        commandKeyMouseMonitor = nil
     }
 
     override func close() {
@@ -163,10 +250,14 @@ class FloatingPanel: NSPanel {
         super.close()
         searchViewModel.query = ""
         searchViewModel.isChatMode = false
+        searchViewModel.isCommandKeyMode = false
+        searchViewModel.isMinimalMode = false
         searchViewModel.chatHistory = []
         searchViewModel.claudeManager = nil
         searchViewModel.currentSessionId = nil
         isTerminalMode = false
+        isCommandKeyVisible = false
+        isCommandKeyHeld = false
     }
 
     // Handle Escape: stop streaming if active, otherwise close

--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -5,6 +5,38 @@ struct SearchView: View {
     @State private var textHeight: CGFloat = 18
 
     var body: some View {
+        if viewModel.isMinimalMode {
+            minimalIndicator
+        } else {
+            fullPanel
+        }
+    }
+
+    private var minimalIndicator: some View {
+        Group {
+            if let icon = viewModel.hoveredContextIcon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 20, height: 20)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+            } else {
+                Image(systemName: "command")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.primary)
+            }
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .shadow(color: .black.opacity(0.12), radius: 2, x: 0, y: 1)
+        .shadow(color: .black.opacity(0.08), radius: 8, x: 0, y: 4)
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.primary.opacity(0.15), lineWidth: 0.5))
+        .padding(16)
+    }
+
+    private var fullPanel: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Selected/highlighted text
             if !viewModel.selectedText.isEmpty {
@@ -41,20 +73,22 @@ struct SearchView: View {
                     .padding(.horizontal, 8)
             }
 
-            // Command input at the bottom
-            HStack(alignment: .top, spacing: 4) {
-                Text(">")
-                    .font(.system(size: 13, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .padding(.top, 1)
+            // Command input at the bottom — hidden while ⌘ is held
+            if !viewModel.isCommandKeyMode {
+                HStack(alignment: .top, spacing: 4) {
+                    Text(">")
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .padding(.top, 1)
 
-                FocusedTextField(text: $viewModel.query, textHeight: $textHeight, onSubmit: {
-                    viewModel.submitMessage()
-                })
-                .frame(height: textHeight)
+                    FocusedTextField(text: $viewModel.query, textHeight: $textHeight, onSubmit: {
+                        viewModel.submitMessage()
+                    })
+                    .frame(height: textHeight)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 7)
         }
         .frame(minWidth: 180, maxWidth: 360)
         .fixedSize()

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -9,6 +9,8 @@ class SearchViewModel: ObservableObject {
     @Published var hoveredContextIcon: NSImage?
     @Published var selectedText: String = ""
     @Published var isChatMode = false
+    @Published var isCommandKeyMode = false
+    @Published var isMinimalMode = false
     @Published var claudeManager: ClaudeProcessManager?
     @Published var chatHistory: [(role: String, text: String)] = []
     @Published var lastScreenshotStatus: String = ""


### PR DESCRIPTION
Implements hold-⌘ as an alternative activation method for the element detection panel.

**Feature:** Press and hold ⌘ to show a minimal icon indicator at the cursor. Move the cursor to expand it into the full panel with element context detection. Release ⌘ to anchor the panel and show the input field for typing.

**Behavior:** Text preservation across re-presses, cursor-following while held, and automatic dismissal on cursor move (if no message sent). Provides discoverable feedback without interrupting the user's workflow.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>