### PR TITLE
Auto-scroll to bottom of chat

### DIFF
--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -862,6 +862,21 @@ struct ChatView: View {
                         proxy.scrollTo("bottom", anchor: .bottom)
                     }
                 }
+                .onChange(of: viewModel.chatHistory.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.events.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.status) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
             }
 
             // Input field


### PR DESCRIPTION
## Summary
- Auto-scroll chat view to bottom as new messages, tool calls, thinking blocks, and status changes arrive
- Ensures the latest content is always visible during active streaming

## Implementation
Added `onChange` handlers for `chatHistory.count`, `events.count`, and `status` to scroll to the bottom marker alongside the existing `outputText` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)