### PR TITLE
Raise floating panel above all windows in z-axis

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -31,7 +31,7 @@ class FloatingPanel: NSPanel {
         )
 
         isFloatingPanel = true
-        level = .floating
+        level = .screenSaver
         isOpaque = false
         backgroundColor = .clear
         hasShadow = false


### PR DESCRIPTION
## Summary
- Changed the floating panel's window level from `.floating` to `.screenSaver`
- This ensures the panel stays above all other application windows and UI elements while active

## Test plan
- [ ] Verify floating panel appears above other app windows
- [ ] Verify floating panel appears above menu bars and status items
- [ ] Test with full-screen applications
- [ ] Confirm panel dismisses and restores focus correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)