### PR TITLE
Add app bundle and DMG packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build/
 .swiftpm/
+dist/

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@ BINARY    := .build/debug/HyperPointer
 CERT_NAME := HyperPointer Dev
 BUNDLE_ID := com.hyperpointer.app
 USER_TCC  := $(HOME)/Library/Application Support/com.apple.TCC/TCC.db
+APP_PATH  := dist/HyperPointer.app
+DMG_PATH  := dist/HyperPointer.dmg
 
-.PHONY: build run sign grant reset-tcc cert-instructions
+.PHONY: build run sign app install dmg grant reset-tcc cert-instructions
 
 # Build and sign (sign only if cert exists)
 build:
@@ -20,6 +22,15 @@ sign:
 
 run: build
 	"$(BINARY)"
+
+app:
+	./scripts/build-app.sh
+
+install:
+	./scripts/build-app.sh --install
+
+dmg:
+	./scripts/build-dmg.sh
 
 # Create a self-signed code-signing cert via Keychain Access (one-time setup).
 cert-instructions:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,33 @@ make build
 ./.build/debug/HyperPointer
 ```
 
+To package it as a normal macOS app bundle:
+
+```bash
+make app
+open dist/HyperPointer.app
+```
+
+To install the app into `/Applications`:
+
+```bash
+make install
+```
+
+If your shell user cannot write to `/Applications`, rerun with `sudo` or choose a different destination:
+
+```bash
+sudo make install
+INSTALL_DIR="$HOME/Applications" make install
+```
+
+To build a drag-to-install disk image:
+
+```bash
+make dmg
+open dist/HyperPointer.dmg
+```
+
 On first launch, macOS will prompt you to grant Accessibility and Screen Recording permissions. It will also show Automation permission dialogs for any apps currently running — click Allow for each. These are one-time prompts; macOS remembers your choices permanently.
 
 To skip all permission dialogs entirely, run once after building:
@@ -35,6 +62,12 @@ sudo make grant
 ```
 
 This writes the grants directly to the TCC database so no popups ever appear.
+
+The `.app` and `.dmg` targets default to ad-hoc signing so they work cleanly on the local machine. If you want a distributable artifact for other Macs, pass a real Developer ID identity and notarize the result:
+
+```bash
+SIGN_MODE=identity SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" make dmg
+```
 
 ## Usage
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,0 +1,128 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="HyperPointer"
+CONFIGURATION="${BUILD_CONFIGURATION:-release}"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
+APP_PATH="$DIST_DIR/$APP_NAME.app"
+INSTALL_AFTER_BUILD=0
+RUN_AFTER_BUILD=0
+SIGN_IDENTITY="${SIGN_IDENTITY:-}"
+SIGN_MODE="ad-hoc"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --configuration <debug|release>  Build configuration (default: release)
+  --output-dir <path>              Artifact directory (default: ./dist)
+  --install                        Copy the built app into /Applications
+  --run                            Open the built app after packaging
+  --sign-identity <identity>       macOS signing identity to use
+  --sign-mode <ad-hoc|identity|skip>
+                                   Signing mode (default: ad-hoc)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configuration)
+      CONFIGURATION="${2:?missing value for --configuration}"
+      shift 2
+      ;;
+    --output-dir)
+      DIST_DIR="${2:?missing value for --output-dir}"
+      APP_PATH="$DIST_DIR/$APP_NAME.app"
+      shift 2
+      ;;
+    --install)
+      INSTALL_AFTER_BUILD=1
+      shift
+      ;;
+    --run)
+      RUN_AFTER_BUILD=1
+      shift
+      ;;
+    --sign-identity)
+      SIGN_IDENTITY="${2:?missing value for --sign-identity}"
+      shift 2
+      ;;
+    --sign-mode)
+      SIGN_MODE="${2:?missing value for --sign-mode}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+case "$SIGN_MODE" in
+  ad-hoc|identity|skip)
+    ;;
+  *)
+    echo "Unsupported sign mode: $SIGN_MODE" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$SIGN_MODE" == "identity" && -z "$SIGN_IDENTITY" ]]; then
+  echo "--sign-mode identity requires --sign-identity." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+swift build -c "$CONFIGURATION"
+
+BIN_DIR="$(swift build -c "$CONFIGURATION" --show-bin-path)"
+BINARY_PATH="$BIN_DIR/$APP_NAME"
+CONTENTS_PATH="$APP_PATH/Contents"
+MACOS_PATH="$CONTENTS_PATH/MacOS"
+RESOURCES_PATH="$CONTENTS_PATH/Resources"
+
+rm -rf "$APP_PATH"
+mkdir -p "$MACOS_PATH" "$RESOURCES_PATH"
+cp "$BINARY_PATH" "$MACOS_PATH/$APP_NAME"
+cp "$ROOT_DIR/Sources/Info.plist" "$CONTENTS_PATH/Info.plist"
+
+if [[ "$SIGN_MODE" != "skip" ]]; then
+  xattr -cr "$APP_PATH" 2>/dev/null || true
+
+  if [[ "$SIGN_MODE" == "identity" ]]; then
+    codesign \
+      --force \
+      --deep \
+      --sign "$SIGN_IDENTITY" \
+      --timestamp=none \
+      "$APP_PATH"
+  else
+    codesign \
+      --force \
+      --deep \
+      --sign - \
+      --timestamp=none \
+      "$APP_PATH"
+  fi
+fi
+
+echo "Built app bundle: $APP_PATH"
+
+if [[ "$INSTALL_AFTER_BUILD" -eq 1 ]]; then
+  INSTALL_DIR="${INSTALL_DIR:-/Applications}"
+  TARGET_PATH="$INSTALL_DIR/$APP_NAME.app"
+  rm -rf "$TARGET_PATH"
+  ditto "$APP_PATH" "$TARGET_PATH"
+  echo "Installed app bundle: $TARGET_PATH"
+fi
+
+if [[ "$RUN_AFTER_BUILD" -eq 1 ]]; then
+  open "$APP_PATH"
+fi

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,151 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+APP_NAME="HyperPointer"
+CONFIGURATION="${BUILD_CONFIGURATION:-release}"
+DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
+APP_PATH="$DIST_DIR/$APP_NAME.app"
+DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
+VOLUME_NAME="${DMG_VOLUME_NAME:-$APP_NAME}"
+SIGN_IDENTITY="${SIGN_IDENTITY:-}"
+SIGN_MODE="${SIGN_MODE:-ad-hoc}"
+TEMP_DIR="$(mktemp -d)"
+STAGING_DIR="$TEMP_DIR/staging"
+MOUNT_DIR=""
+RW_DMG_PATH="$TEMP_DIR/$APP_NAME-rw.dmg"
+DEVICE=""
+
+cleanup() {
+  if [[ -n "$DEVICE" ]]; then
+    hdiutil detach "$DEVICE" -quiet >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --configuration <debug|release>  Build configuration (default: release)
+  --output-dir <path>              Artifact directory (default: ./dist)
+  --volume-name <name>             Mounted DMG volume name (default: HyperPointer)
+  --sign-identity <identity>       macOS signing identity to use for the app build
+  --sign-mode <ad-hoc|identity|skip>
+                                   Signing mode passed through to build-app.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configuration)
+      CONFIGURATION="${2:?missing value for --configuration}"
+      shift 2
+      ;;
+    --output-dir)
+      DIST_DIR="${2:?missing value for --output-dir}"
+      APP_PATH="$DIST_DIR/$APP_NAME.app"
+      DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
+      shift 2
+      ;;
+    --volume-name)
+      VOLUME_NAME="${2:?missing value for --volume-name}"
+      shift 2
+      ;;
+    --sign-identity)
+      SIGN_IDENTITY="${2:?missing value for --sign-identity}"
+      shift 2
+      ;;
+    --sign-mode)
+      SIGN_MODE="${2:?missing value for --sign-mode}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+MOUNT_DIR="/Volumes/$VOLUME_NAME"
+
+mkdir -p "$DIST_DIR" "$STAGING_DIR"
+
+build_app_args=(
+  --configuration "$CONFIGURATION"
+  --output-dir "$DIST_DIR"
+  --sign-mode "$SIGN_MODE"
+)
+
+if [[ -n "$SIGN_IDENTITY" ]]; then
+  build_app_args+=(--sign-identity "$SIGN_IDENTITY")
+fi
+
+"$ROOT_DIR/scripts/build-app.sh" "${build_app_args[@]}"
+
+ditto "$APP_PATH" "$STAGING_DIR/$APP_NAME.app"
+ln -s /Applications "$STAGING_DIR/Applications"
+rm -f "$DMG_PATH"
+
+hdiutil create \
+  -quiet \
+  -fs HFS+ \
+  -volname "$VOLUME_NAME" \
+  -srcfolder "$STAGING_DIR" \
+  -format UDRW \
+  "$RW_DMG_PATH"
+
+DEVICE="$(
+  rmdir "$MOUNT_DIR" >/dev/null 2>&1 || true
+  hdiutil attach \
+    -readwrite \
+    -noverify \
+    -noautoopen \
+    -mountpoint "$MOUNT_DIR" \
+    "$RW_DMG_PATH" | awk 'NR==1 {print $1}'
+)"
+
+open "$MOUNT_DIR"
+sleep 1
+
+osascript <<EOF
+tell application "Finder"
+  tell disk "$VOLUME_NAME"
+    open
+    set current view of container window to icon view
+    set toolbar visible of container window to false
+    set statusbar visible of container window to false
+    set the bounds of container window to {120, 120, 700, 430}
+    set viewOptions to the icon view options of container window
+    set arrangement of viewOptions to not arranged
+    set icon size of viewOptions to 128
+    set text size of viewOptions to 14
+    set position of item "$APP_NAME.app" of container window to {180, 170}
+    set position of item "Applications" of container window to {460, 170}
+    close
+    open
+    update without registering applications
+    delay 2
+  end tell
+end tell
+EOF
+
+sync
+hdiutil detach "$DEVICE" -quiet
+DEVICE=""
+
+hdiutil convert \
+  -quiet \
+  "$RW_DMG_PATH" \
+  -format UDZO \
+  -imagekey zlib-level=9 \
+  -o "$DMG_PATH"
+
+echo "Built installer image: $DMG_PATH"


### PR DESCRIPTION
## Summary
- add reusable scripts to build a signed macOS app bundle in `dist/` and package it into a drag-to-install DMG
- expose the packaging flow through `make app`, `make install`, and `make dmg`
- document the new install/distribution workflow and ignore generated `dist/` artifacts

## Verification
- `make app`
- `make dmg`
- `INSTALL_DIR="$PWD/.context/Applications" make install`