### PR TITLE
Fix Sparkle release signature generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,24 @@ jobs:
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
-          SIG=$(echo "$SPARKLE_PRIVATE_KEY" \
-            | ./sparkle-tools/bin/sign_update dist/HyperPointer.dmg \
-            | grep -o 'sparkle:edSignature="[^"]*"' \
-            | sed 's/sparkle:edSignature="//;s/"//')
-          echo "signature=$SIG" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          if [[ -z "${SPARKLE_PRIVATE_KEY:-}" ]]; then
+            echo "SPARKLE_PRIVATE_KEY is not configured" >&2
+            exit 1
+          fi
+
+          SIG="$(
+            printf '%s' "$SPARKLE_PRIVATE_KEY" \
+              | ./sparkle-tools/bin/sign_update --ed-key-file - -p dist/HyperPointer.dmg
+          )"
+
+          if [[ -z "$SIG" ]]; then
+            echo "Sparkle signature was empty" >&2
+            exit 1
+          fi
+
+          echo "signature=$SIG" >> "$GITHUB_OUTPUT"
 
       # -----------------------------------------------------------------------
       # Update appcast.xml (replaces the entire file with the latest release)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ The `.app` and `.dmg` targets default to ad-hoc signing so they work cleanly on 
 SIGN_MODE=identity SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" make dmg
 ```
 
+## Sparkle Release Signing
+
+The GitHub Actions release job signs the published DMG with Sparkle's Ed25519 key. It expects a `SPARKLE_PRIVATE_KEY` repository secret containing the exported private key contents, not the `sparkle:edSignature` output.
+
+To create or recover the matching keypair:
+
+```bash
+swift package resolve
+./.build/artifacts/sparkle/Sparkle/bin/generate_keys
+```
+
+That command prints the public key to embed in `SUPublicEDKey` inside `Sources/Info.plist`. To export the private key for CI:
+
+```bash
+./.build/artifacts/sparkle/Sparkle/bin/generate_keys -x sparkle-private-key.txt
+```
+
+Copy the contents of `sparkle-private-key.txt` into the `SPARKLE_PRIVATE_KEY` GitHub secret, then delete the file. The release workflow reads that secret with `sign_update --ed-key-file -`, signs `dist/HyperPointer.dmg`, and writes the resulting signature into `appcast.xml`.
+
 ## Usage
 
 - **Ctrl+Space** — Open the panel at your cursor


### PR DESCRIPTION
This fixes the Sparkle signing step in the release workflow so CI passes the private key via --ed-key-file - and fails fast if the signature is missing. It also documents how to generate or export the matching Sparkle keypair and populate the SPARKLE_PRIVATE_KEY GitHub secret. This should prevent future releases from publishing an empty enclosure signature in appcast.xml.