### PR TITLE
Display installed version in status menu

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -159,6 +159,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             button.toolTip = "HyperPointer"
         }
 
+        let bundle = Bundle.main
+        let shortVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        let versionItem = NSMenuItem(title: "HyperPointer v\(shortVersion).\(buildNumber)", action: nil, keyEquivalent: "")
+        versionItem.isEnabled = false
+
         let newPanelItem = NSMenuItem(title: "New Panel", action: #selector(handleStatusNewPanel), keyEquivalent: "n")
         newPanelItem.target = self
 
@@ -169,6 +175,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         quitItem.target = self
 
         let menu = NSMenu()
+        menu.addItem(versionItem)
+        menu.addItem(.separator())
         menu.addItem(newPanelItem)
         menu.addItem(.separator())
         menu.addItem(checkForUpdatesItem)


### PR DESCRIPTION
Adds the app version (v1.0.3 format) as a disabled menu item at the top of the status bar menu. This allows you to immediately see your installed version and compare it to GitHub release tags when checking for updates, solving the versioning tracking issue for verification.

🤖 Generated with Claude Code