### PR TITLE
Fix text visibility in search input field

### DIFF
--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -255,6 +255,7 @@ struct FocusedTextField: NSViewRepresentable {
         textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
         textView.backgroundColor = .clear
         textView.drawsBackground = false
+        textView.textColor = .labelColor
         textView.textContainerInset = .zero
         textView.textContainer?.lineFragmentPadding = 0
         textView.isVerticallyResizable = true


### PR DESCRIPTION
Set explicit text color on NSTextView to ensure typed text is visible in the installed app bundle. The text color now uses NSColor.labelColor which respects the system's light/dark mode appearance. Fixes JMAR-61.