### PR TITLE
Fix: permissions reset after every Sparkle update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,57 @@ jobs:
       - name: Resolve Swift packages
         run: swift package resolve
 
+      # -----------------------------------------------------------------------
+      # Code signing — import a self-signed cert so TCC permissions survive
+      # Sparkle updates. Without a stable signature, each new binary gets a
+      # new ad-hoc hash and macOS re-prompts for every permission on first launch.
+      #
+      # One-time setup (run scripts/create-signing-cert.sh, then store outputs):
+      #   SIGNING_CERT_P12          — base64-encoded .p12 file
+      #   SIGNING_CERT_PASSWORD     — password used when exporting the .p12
+      #   SIGNING_CERT_NAME         — Common Name of the cert (e.g. "HyperPointer")
+      # -----------------------------------------------------------------------
+      - name: Import signing certificate
+        id: signing
+        env:
+          SIGNING_CERT_P12:      ${{ secrets.SIGNING_CERT_P12 }}
+          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
+          SIGNING_CERT_NAME:     ${{ secrets.SIGNING_CERT_NAME }}
+        run: |
+          if [[ -z "${SIGNING_CERT_P12:-}" ]]; then
+            echo "SIGNING_CERT_P12 not set — falling back to ad-hoc signing."
+            echo "sign_mode=ad-hoc"    >> "$GITHUB_OUTPUT"
+            echo "sign_identity="      >> "$GITHUB_OUTPUT"
+          else
+            KEYCHAIN=build.keychain
+            security create-keychain -p "" "$KEYCHAIN"
+            security default-keychain -s "$KEYCHAIN"
+            security unlock-keychain -p "" "$KEYCHAIN"
+            security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+
+            echo "$SIGNING_CERT_P12" | base64 --decode > /tmp/signing.p12
+            security import /tmp/signing.p12 -k "$KEYCHAIN" \
+              -P "$SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
+            rm /tmp/signing.p12
+
+            security set-key-partition-list \
+              -S "apple-tool:,apple:,codesign:" -s -k "" "$KEYCHAIN"
+
+            echo "sign_mode=identity"             >> "$GITHUB_OUTPUT"
+            echo "sign_identity=$SIGNING_CERT_NAME" >> "$GITHUB_OUTPUT"
+            echo "Imported certificate: $SIGNING_CERT_NAME"
+          fi
+
       - name: Build DMG
-        run: ./scripts/build-dmg.sh
+        env:
+          SIGN_MODE:     ${{ steps.signing.outputs.sign_mode }}
+          SIGN_IDENTITY: ${{ steps.signing.outputs.sign_identity }}
+        run: |
+          ARGS=(--sign-mode "$SIGN_MODE")
+          if [[ -n "$SIGN_IDENTITY" ]]; then
+            ARGS+=(--sign-identity "$SIGN_IDENTITY")
+          fi
+          ./scripts/build-dmg.sh "${ARGS[@]}"
 
       - name: Collect DMG metadata
         id: dmg

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,18 @@ run: build
 	"$(BINARY)"
 
 app:
-	./scripts/build-app.sh
+	@if security find-identity -v -p codesigning 2>/dev/null | grep -q "$(CERT_NAME)"; then \
+		./scripts/build-app.sh --sign-mode identity --sign-identity "$(CERT_NAME)"; \
+	else \
+		./scripts/build-app.sh; \
+	fi
 
 install:
-	./scripts/build-app.sh --install
+	@if security find-identity -v -p codesigning 2>/dev/null | grep -q "$(CERT_NAME)"; then \
+		./scripts/build-app.sh --install --sign-mode identity --sign-identity "$(CERT_NAME)"; \
+	else \
+		./scripts/build-app.sh --install; \
+	fi
 
 dmg:
 	./scripts/build-dmg.sh

--- a/scripts/create-signing-cert.sh
+++ b/scripts/create-signing-cert.sh
@@ -1,0 +1,76 @@
+#!/bin/zsh
+# One-time setup: create a self-signed code-signing certificate and export it
+# so CI can import it for stable signing.
+#
+# Usage: ./scripts/create-signing-cert.sh [cert-name]
+#   cert-name defaults to "HyperPointer"
+#
+# After running, add three GitHub repository secrets:
+#   SIGNING_CERT_P12          — contents of the .p12.b64 file printed below
+#   SIGNING_CERT_PASSWORD     — password printed by this script
+#   SIGNING_CERT_NAME         — the cert name (e.g. "HyperPointer")
+#
+# Why this matters:
+#   Ad-hoc signed apps get a TCC code requirement tied to the binary hash.
+#   Every Sparkle update changes the binary, so the hash changes, and macOS
+#   re-prompts for all permissions. A stable self-signed cert produces a
+#   requirement tied to the cert anchor hash — stable across all builds
+#   signed with the same cert.
+set -euo pipefail
+
+CERT_NAME="${1:-HyperPointer}"
+P12_FILE="${CERT_NAME// /_}.p12"
+B64_FILE="${P12_FILE}.b64"
+PASSWORD=$(openssl rand -base64 18)
+
+echo ""
+echo "Creating self-signed code-signing certificate: '$CERT_NAME'"
+echo ""
+
+TMPDIR_CERTS=$(mktemp -d)
+KEY_FILE="$TMPDIR_CERTS/key.pem"
+CERT_FILE="$TMPDIR_CERTS/cert.pem"
+
+# Generate RSA key
+openssl genrsa -out "$KEY_FILE" 2048 2>/dev/null
+
+# Generate self-signed cert valid for 30 years
+openssl req -new -x509 \
+  -key "$KEY_FILE" \
+  -out "$CERT_FILE" \
+  -days 10950 \
+  -subj "/CN=$CERT_NAME/O=$CERT_NAME/C=US" \
+  -addext "keyUsage=critical,digitalSignature,keyCertSign" \
+  -addext "extendedKeyUsage=codeSigning" 2>/dev/null
+
+# Bundle into PKCS#12
+openssl pkcs12 -export \
+  -in "$CERT_FILE" \
+  -inkey "$KEY_FILE" \
+  -out "$P12_FILE" \
+  -name "$CERT_NAME" \
+  -passout "pass:$PASSWORD" 2>/dev/null
+
+rm -rf "$TMPDIR_CERTS"
+
+# Import into login keychain so local builds can sign immediately
+# -A allows any application to access the key (avoids codesign prompts)
+security import "$P12_FILE" \
+  -k ~/Library/Keychains/login.keychain-db \
+  -P "$PASSWORD" \
+  -T /usr/bin/codesign \
+  -A 2>/dev/null
+
+# Base64-encode the p12 for GitHub Secrets
+base64 < "$P12_FILE" > "$B64_FILE"
+
+echo "============================================================"
+echo "Certificate created and imported into your login keychain."
+echo ""
+echo "Add these three GitHub repository secrets:"
+echo "  https://github.com/jasPreMar/hyper-pointer/settings/secrets/actions"
+echo ""
+echo "  SIGNING_CERT_NAME     = $CERT_NAME"
+echo "  SIGNING_CERT_PASSWORD = $PASSWORD"
+echo "  SIGNING_CERT_P12      = (run: pbcopy < $B64_FILE)"
+echo "============================================================"


### PR DESCRIPTION
## Summary
- Root cause: ad-hoc signing ties TCC permissions to the binary hash. Every Sparkle update produces a new hash → macOS re-prompts for Accessibility, Screen Recording, and Apple Events on the next launch.
- Fix: sign releases with a stable self-signed cert. TCC stores an `anchor = H"cert-hash"` requirement that matches any binary signed by the same cert, so permissions survive updates.

## Changes
- `release.yml` — imports signing cert from new GitHub Secrets, passes `--sign-mode identity` to `build-dmg.sh`; gracefully falls back to ad-hoc if secrets aren't set
- `Makefile` — `app`/`install` targets use cert identity when it's in the keychain
- `scripts/create-signing-cert.sh` — one-time helper to create+export the cert (already ran; secrets already added to the repo)

## Test plan
- [ ] Merge and let CI run — confirm "Import signing certificate" step succeeds in the release job
- [ ] Install the built DMG, grant permissions, update to the next release, confirm no re-prompts

Closes JMAR-62

🤖 Generated with [Claude Code](https://claude.com/claude-code)