### PR TITLE
Fix header drag without breaking hover/close button

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -76,6 +76,33 @@ class FloatingPanel: NSPanel {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
 
+    /// In chat mode, allow dragging the window from any non-interactive area
+    /// (header text, icons, transcript) without needing a dedicated drag view.
+    /// Interactive controls (close button, text input, scroll view) are passed
+    /// through normally so they keep working.
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, isTerminalMode,
+           let contentView = contentView {
+            let point = contentView.convert(event.locationInWindow, from: nil)
+            if let hit = contentView.hitTest(point), !isInteractiveControl(hit) {
+                performDrag(with: event)
+                return
+            }
+        }
+        super.sendEvent(event)
+    }
+
+    private func isInteractiveControl(_ view: NSView) -> Bool {
+        var v: NSView? = view
+        while let current = v {
+            if current is NSControl || current is NSTextView || current is NSScrollView {
+                return true
+            }
+            v = current.superview
+        }
+        return false
+    }
+
     func show(at point: NSPoint) {
         searchViewModel.query = ""
         searchViewModel.updateHoveredApp()

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -828,7 +828,6 @@ struct ChatView: View {
                         showsCloseButtonOnHover: true,
                         onClose: viewModel.onClose
                     )
-                    .overlay(DragArea())
                 } else {
                     if !viewModel.selectedText.isEmpty {
                         PanelHeaderSection(viewModel: viewModel)
@@ -840,7 +839,6 @@ struct ChatView: View {
                     ChatCloseRow(viewModel: viewModel)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 7)
-                    .overlay(DragArea())
                 }
 
                 Divider()
@@ -951,43 +949,3 @@ private struct ChatCloseRow: View {
     }
 }
 
-// MARK: - Drag Area (makes the header draggable via native window drag)
-
-struct DragArea: NSViewRepresentable {
-    func makeNSView(context: Context) -> DragView {
-        let view = DragView()
-        view.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        view.setContentHuggingPriority(.defaultLow, for: .vertical)
-        return view
-    }
-    func updateNSView(_ nsView: DragView, context: Context) {}
-}
-
-class DragView: NSView {
-    override func mouseDown(with event: NSEvent) {
-        window?.performDrag(with: event)
-    }
-
-    /// Pass through clicks that land on an interactive control (e.g. the close button)
-    /// so those controls can still receive their events. Drags anywhere else in the
-    /// overlay initiate native window dragging via mouseDown.
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        // `point` is in the superview's coordinate system.
-        guard let superview = superview else { return super.hitTest(point) }
-        for sibling in superview.subviews where sibling !== self {
-            if let hit = sibling.hitTest(point), hasInteractiveAncestor(hit, stopAt: superview) {
-                return nil
-            }
-        }
-        return super.hitTest(point)
-    }
-
-    private func hasInteractiveAncestor(_ view: NSView, stopAt limit: NSView) -> Bool {
-        var current: NSView? = view
-        while let v = current, v !== limit {
-            if v is NSControl || v is NSTextView { return true }
-            current = v.superview
-        }
-        return false
-    }
-}


### PR DESCRIPTION
## Summary
Previous attempt used a DragArea overlay which blocked SwiftUI's hover tracking — breaking the close-button-on-hover in the chat header.

This moves the window-drag logic to `FloatingPanel.sendEvent`, which intercepts `leftMouseDown` in chat mode and calls `performDrag` for any hit view that isn't an `NSControl`, `NSTextView`, or `NSScrollView`. The header (text, icons) is now fully draggable via native `performDrag`, while the close button, text input, and scroll area all work normally.

Fixes JMAR-70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)