### PR TITLE
Fix sendEvent hitTest coordinate for header drag

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -83,8 +83,11 @@ class FloatingPanel: NSPanel {
     override func sendEvent(_ event: NSEvent) {
         if event.type == .leftMouseDown, isTerminalMode,
            let contentView = contentView {
-            let point = contentView.convert(event.locationInWindow, from: nil)
-            if let hit = contentView.hitTest(point), !isInteractiveControl(hit) {
+            // hitTest expects a point in the receiver's superview coordinate system,
+            // which for a borderless panel matches window base coordinates directly.
+            // Do NOT use convert(from: nil) — NSHostingView is flipped so that
+            // conversion would produce wrong Y values and hitTest would miss.
+            if let hit = contentView.hitTest(event.locationInWindow), !isInteractiveControl(hit) {
                 performDrag(with: event)
                 return
             }


### PR DESCRIPTION
## Summary
`NSHostingView.isFlipped = true`, so the previous `contentView.convert(event.locationInWindow, from: nil)` was flipping the Y-axis before passing to `hitTest`. Since `hitTest` expects superview coordinates (bottom-left origin), the converted point landed in the wrong area — `hitTest` returned `nil` for the header, so `performDrag` was never called.

Fix: pass `event.locationInWindow` directly to `hitTest`. For a borderless panel the content view's superview coordinates match window base coordinates, so no conversion is needed.

Fixes JMAR-70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)