### PR TITLE
Make chat windows behave like normal windows

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -190,6 +190,29 @@ class FloatingPanel: NSPanel {
         isCursorFollowing = false
         removeAllMonitors()
 
+        // Convert to a normal titled window so it behaves like any other window:
+        // standard z-ordering (click to front, other windows can go in front),
+        // native traffic-light controls, and user-resizable.
+        let previousTop = frame.maxY
+        let previousOriginX = frame.minX
+        styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
+        level = .normal
+        titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        isOpaque = true
+        backgroundColor = .windowBackgroundColor
+        hasShadow = true
+        let chatSize = CGSize(width: 460, height: 520)
+        setContentSize(chatSize)
+        // Preserve position of the top-left corner, clamped to screen
+        var nextOrigin = NSPoint(x: previousOriginX, y: previousTop - frame.height)
+        if let scr = screen ?? NSScreen.screens.first(where: { $0.visibleFrame.intersects(frame) }) ?? NSScreen.main {
+            let sf = scr.visibleFrame
+            nextOrigin.x = max(sf.minX, min(nextOrigin.x, sf.maxX - frame.width))
+            nextOrigin.y = max(sf.minY, min(nextOrigin.y, sf.maxY - frame.height))
+        }
+        setFrameOrigin(nextOrigin)
+
         // Switch to chat mode — the PanelContentView handles the rest
         searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query))
         searchViewModel.query = ""
@@ -234,6 +257,7 @@ class FloatingPanel: NSPanel {
     }
 
     private func resizeToContentSize(_ size: CGSize, preserveTopEdge: Bool) {
+        guard !isTerminalMode else { return }
         let normalizedSize = CGSize(
             width: min(ceil(size.width), Self.maxPanelDimension),
             height: min(ceil(size.height), Self.maxPanelDimension)
@@ -386,6 +410,14 @@ class FloatingPanel: NSPanel {
         removeAllMonitors()
         voiceController.cancel()
         super.close()
+        // Restore panel appearance for potential reuse
+        if isTerminalMode {
+            styleMask = [.borderless, .nonactivatingPanel]
+            level = .screenSaver
+            isOpaque = false
+            backgroundColor = .clear
+            hasShadow = false
+        }
         searchViewModel.query = ""
         searchViewModel.isChatMode = false
         searchViewModel.isCommandKeyMode = false

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -813,82 +813,72 @@ struct ChatView: View {
     @ObservedObject var viewModel: SearchViewModel
     @State private var textWidth: CGFloat = FocusedTextField.minWidth
     @State private var textHeight: CGFloat = 18
-    private let fixedChatHeight: CGFloat = 360
 
     private var hasContextRow: Bool {
         viewModel.hoveredParts.last != nil
     }
 
     var body: some View {
-        PanelSurface(fixedHeight: fixedChatHeight) {
-            VStack(spacing: 0) {
-                if hasContextRow {
-                    PanelHeaderSection(
-                        viewModel: viewModel,
-                        showsCloseButtonOnHover: true,
-                        onClose: viewModel.onClose
-                    )
-                } else {
-                    if !viewModel.selectedText.isEmpty {
-                        PanelHeaderSection(viewModel: viewModel)
-
-                        Divider()
-                            .padding(.horizontal, 8)
-                    }
-
-                    ChatCloseRow(viewModel: viewModel)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 7)
-                }
-
+        VStack(spacing: 0) {
+            if hasContextRow {
+                PanelHeaderSection(
+                    viewModel: viewModel,
+                    showsCloseButtonOnHover: false,
+                    onClose: viewModel.onClose
+                )
+            } else if !viewModel.selectedText.isEmpty {
+                PanelHeaderSection(viewModel: viewModel)
                 Divider()
                     .padding(.horizontal, 8)
+            }
 
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        HStack(alignment: .top, spacing: 0) {
-                            transcriptContent
-                            Spacer(minLength: 0)
-                        }
+            Divider()
+                .padding(.horizontal, 8)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    HStack(alignment: .top, spacing: 0) {
+                        transcriptContent
+                        Spacer(minLength: 0)
                     }
-                    .frame(maxHeight: .infinity, alignment: .top)
-                    .onAppear {
+                }
+                .frame(maxHeight: .infinity, alignment: .top)
+                .onAppear {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+                .onChange(of: viewModel.claudeManager?.outputText) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
                         proxy.scrollTo("bottom", anchor: .bottom)
                     }
-                    .onChange(of: viewModel.claudeManager?.outputText) { _, _ in
-                        withAnimation(.easeOut(duration: 0.1)) {
-                            proxy.scrollTo("bottom", anchor: .bottom)
-                        }
-                    }
-                    .onChange(of: viewModel.chatHistory.count) { _, _ in
-                        withAnimation(.easeOut(duration: 0.1)) {
-                            proxy.scrollTo("bottom", anchor: .bottom)
-                        }
-                    }
-                    .onChange(of: viewModel.claudeManager?.events.count) { _, _ in
-                        withAnimation(.easeOut(duration: 0.1)) {
-                            proxy.scrollTo("bottom", anchor: .bottom)
-                        }
-                    }
-                    .onChange(of: viewModel.claudeManager?.status) { _, _ in
-                        withAnimation(.easeOut(duration: 0.1)) {
-                            proxy.scrollTo("bottom", anchor: .bottom)
-                        }
+                }
+                .onChange(of: viewModel.chatHistory.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
                     }
                 }
-
-                Divider()
-                    .padding(.horizontal, 8)
-
-                PanelInputRow(
-                    viewModel: viewModel,
-                    textWidth: $textWidth,
-                    textHeight: $textHeight,
-                    expandsTextField: true
-                )
+                .onChange(of: viewModel.claudeManager?.events.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.status) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
             }
-            .frame(maxHeight: .infinity, alignment: .top)
+
+            Divider()
+                .padding(.horizontal, 8)
+
+            PanelInputRow(
+                viewModel: viewModel,
+                textWidth: $textWidth,
+                textHeight: $textHeight,
+                expandsTextField: true
+            )
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var transcriptContent: some View {
@@ -930,22 +920,6 @@ struct ChatView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-    }
-}
-
-private struct ChatCloseRow: View {
-    @ObservedObject var viewModel: SearchViewModel
-
-    var body: some View {
-        HStack {
-            Button(action: { viewModel.onClose?() }) {
-                Circle()
-                    .fill(Color(nsColor: .systemRed))
-                    .frame(width: 12, height: 12)
-            }
-            .buttonStyle(.plain)
-            Spacer()
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Convert chat/terminal panels to standard titled, resizable windows with native macOS chrome
- When transitioning to chat mode, the floating panel is converted to a normal window at level `.normal` for proper z-ordering
- Clicking the chat window brings it to front; other windows can be brought in front of it
- Native traffic-light controls (close, minimize) and resize handles replace custom close button

## Changes
- **FloatingPanel.swift**: Updated `transitionToTerminal()` to set window style mask, title bar, and level; skip auto-resize in chat mode
- **TerminalContentView.swift**: Removed `PanelSurface` wrapper and `ChatCloseRow` (native chrome handles this), simplified ChatView to fill window

🤖 Generated with Claude Code