### PR TITLE
Make voice mode not stuck in one place

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -235,7 +235,7 @@ class FloatingPanel: NSPanel {
     }
 
     private func positionAtCursor() {
-        guard !isTerminalMode, !searchViewModel.isVoiceModeActive else { return }
+        guard !isTerminalMode else { return }
         let fittingSize = hostingView.fittingSize
         setContentSize(fittingSize)
 
@@ -495,20 +495,6 @@ class FloatingPanel: NSPanel {
               isCursorFollowing,
               !searchViewModel.isVoiceModeActive else { return }
 
-        if let monitor = globalMouseMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalMouseMonitor = nil
-        }
-        if let monitor = localMouseMonitor {
-            NSEvent.removeMonitor(monitor)
-            localMouseMonitor = nil
-        }
-        if let monitor = commandKeyMouseMonitor {
-            NSEvent.removeMonitor(monitor)
-            commandKeyMouseMonitor = nil
-        }
-
-        isCursorFollowing = false
         searchViewModel.isCommandKeyMode = false
         searchViewModel.isMinimalMode = false
         voiceController.start()


### PR DESCRIPTION
## Summary

Allow the floating panel to continue following the mouse and tracking objects while voice dictation is active. The panel previously froze in place during voice recording due to a guard condition that prevented cursor positioning and removal of mouse event monitors.

## Changes

- Remove `isVoiceModeActive` check from `positionAtCursor()` guard so position updates continue during voice mode
- Keep mouse event monitors running during voice mode instead of tearing them down
- Cursor tracking and object hovering work seamlessly throughout voice recording

When recording stops and the message is sent, it automatically uses whatever object was being hovered at send time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)