### PR TITLE
Fix tool calls and thoughts appearing below response text

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -212,14 +212,15 @@ class FloatingPanel: NSPanel {
         setFrameOrigin(nextOrigin)
 
         // Switch to chat mode — the PanelContentView handles the rest
-        searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query))
+        searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query, events: []))
         searchViewModel.query = ""
 
         let manager = ClaudeProcessManager()
         manager.onComplete = { [weak self] response in
-            // Clear streaming text before appending to history to avoid duplicate display
+            let completedEvents = manager.events
             manager.outputText = ""
-            self?.searchViewModel.chatHistory.append((role: "assistant", text: response))
+            manager.events = []
+            self?.searchViewModel.chatHistory.append((role: "assistant", text: response, events: completedEvents))
             // Capture session ID for follow-up messages
             if let sid = manager.sessionId {
                 self?.searchViewModel.currentSessionId = sid

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -19,7 +19,7 @@ class SearchViewModel: ObservableObject {
     @Published var isCommandKeyMode = false
     @Published var isMinimalMode = false
     @Published var claudeManager: ClaudeProcessManager?
-    @Published var chatHistory: [(role: String, text: String)] = []
+    @Published var chatHistory: [(role: String, text: String, events: [StreamEvent])] = []
     @Published var voiceState: VoiceState = .idle
     @Published var voiceLevel: CGFloat = 0
     var currentSessionId: String?
@@ -45,13 +45,14 @@ class SearchViewModel: ObservableObject {
 
         if isChatMode {
             // Follow-up message — resume the existing session
-            chatHistory.append((role: "user", text: message))
+            chatHistory.append((role: "user", text: message, events: []))
             query = ""
             let manager = ClaudeProcessManager()
             manager.onComplete = { [weak self] response in
-                // Clear streaming text before appending to history to avoid duplicate display
+                let completedEvents = manager.events
                 manager.outputText = ""
-                self?.chatHistory.append((role: "assistant", text: response))
+                manager.events = []
+                self?.chatHistory.append((role: "assistant", text: response, events: completedEvents))
                 // Update session ID in case it changed
                 if let sid = manager.sessionId {
                     self?.currentSessionId = sid

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -520,18 +520,19 @@ struct ToolCallEventRow: View {
 // MARK: - Events Summary View
 
 struct EventsSummaryView: View {
-    @ObservedObject var manager: ClaudeProcessManager
+    let events: [StreamEvent]
+    let isDone: Bool
     @State private var isExpanded = false
 
     private var toolCallCount: Int {
-        manager.events.filter {
+        events.filter {
             if case .toolCall = $0 { return true }
             return false
         }.count
     }
 
     private var messageCount: Int {
-        manager.events.filter {
+        events.filter {
             if case .thinking = $0 { return true }
             return false
         }.count
@@ -549,9 +550,9 @@ struct EventsSummaryView: View {
     }
 
     var body: some View {
-        if manager.events.isEmpty {
+        if events.isEmpty {
             EmptyView()
-        } else if manager.status == .done {
+        } else if isDone {
             // Collapsed summary with expand/collapse toggle
             VStack(alignment: .leading, spacing: 4) {
                 Button(action: { withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() } }) {
@@ -573,14 +574,14 @@ struct EventsSummaryView: View {
                 .buttonStyle(.plain)
 
                 if isExpanded {
-                    ForEach(manager.events) { event in
+                    ForEach(events) { event in
                         eventRow(for: event)
                     }
                 }
             }
         } else {
             // Live streaming — show all events individually
-            ForEach(manager.events) { event in
+            ForEach(events) { event in
                 eventRow(for: event)
             }
         }
@@ -826,12 +827,13 @@ struct ChatView: View {
                         .font(.system(size: 12, design: .monospaced))
                         .foregroundColor(.secondary)
                 } else {
+                    EventsSummaryView(events: entry.events, isDone: true)
                     AssistantMarkdown(text: entry.text)
                 }
             }
 
             if let manager = viewModel.claudeManager {
-                EventsSummaryView(manager: manager)
+                EventsSummaryView(events: manager.events, isDone: manager.status == .done)
             }
 
             if let manager = viewModel.claudeManager,


### PR DESCRIPTION
## Summary
Tool calls and thinking blocks now render **above** the assistant's response text in the conversation thread, not below.

Events are stored with each assistant message in chat history and rendered before the response text. EventsSummaryView is refactored to take static events plus an isDone flag instead of observing the manager, enabling proper rendering for both active turns and historical entries. Events are cleared from the manager when a turn completes, preventing duplicates.

## Test plan
- [ ] Start a chat and trigger tool calls or thinking
- [ ] Verify tool calls/thoughts appear above the assistant's response while streaming
- [ ] Verify they remain above after streaming completes and in subsequent turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)