### PR TITLE
Restore background appcast check for update badge

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -60,12 +60,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let onboardingSeenKey = "hasShownOnboarding"
     private var checkForUpdatesItem: NSMenuItem?
     private var updateDot: NSView?
+    private var updateCheckTimer: Timer?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         sharedAppDelegate = self
         setupMainMenu()
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
         setupStatusItem()
+        checkForUpdateInBackground()
         setupRightClickTapIfNeeded()
         showOnboardingIfNeeded()
 
@@ -301,6 +303,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let panel = FloatingPanel()
         panels.append(panel)
         panel.show(at: point)
+    }
+
+    /// Fetches the appcast in the background and shows the update badge if a newer version exists.
+    /// Repeats every hour so the badge appears without waiting for Sparkle's scheduled check.
+    private func checkForUpdateInBackground() {
+        let check = { [weak self] in
+            guard let feedURLString = Bundle.main.infoDictionary?["SUFeedURL"] as? String,
+                  let feedURL = URL(string: feedURLString) else { return }
+            let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+            URLSession.shared.dataTask(with: feedURL) { data, _, _ in
+                guard let data = data,
+                      let xml = String(data: data, encoding: .utf8) else { return }
+                if let range = xml.range(of: "(?<=<sparkle:version>)\\d+(?=</sparkle:version>)", options: .regularExpression),
+                   let remoteBuild = Int(xml[range]),
+                   let localBuild = Int(currentBuild),
+                   remoteBuild > localBuild {
+                    DispatchQueue.main.async {
+                        self?.showUpdateBadge()
+                    }
+                }
+            }.resume()
+        }
+        check()
+        updateCheckTimer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { _ in check() }
     }
 
     private func showUpdateBadge() {


### PR DESCRIPTION
## Summary
- Re-adds `checkForUpdateInBackground()` that was lost during the onboarding merge
- Fetches the appcast XML on launch and hourly to compare build numbers
- Shows the red dot badge and "Update Available" text immediately without user interaction

## Test plan
- [ ] Launch app with a lower build number than the appcast — badge should appear within seconds
- [ ] Launch app with a current build number — no badge should appear