### PR TITLE
docs: add tester warnings to onboarding

### DIFF
--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -413,9 +413,36 @@ private struct FinishStep: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Before you start")
+                    .font(.system(size: 14, weight: .semibold))
+
+                VStack(alignment: .leading, spacing: 6) {
+                    testerNote("Every request uses your Claude Code plan. Normal usage is modest, but long sessions add up.")
+                    testerNote("Claude runs commands on your Mac without asking first. Be intentional about what you tell it to do.")
+                    testerNote("Screenshots of the window you point at are sent to Claude as context. Avoid hovering over sensitive info you wouldn't paste into a chat.")
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.orange.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+
             Spacer()
         }
         .padding(28)
+    }
+
+    private func testerNote(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text("\u{2022}")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     private func finishRow(_ title: String, ready: Bool) -> some View {


### PR DESCRIPTION
## Summary

Adds a prominent "Before you start" warning section to the onboarding finish screen that testers see right before using the app. Covers three critical points:

- **Cost**: Every request uses the tester's Claude Code plan; long sessions accumulate tokens
- **Autonomy**: Claude runs commands without asking first — be intentional with requests
- **Privacy**: Screenshots are sent to Claude for context; avoid hovering over sensitive data

## Why

With 10 friends testing the app, it's important they understand the implications before clicking finish. The warning is concise enough to actually read and specific enough to set proper expectations around cost, permissions, and data privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)