### PR TITLE
Fix automatic update badge with Sparkle interval and CDN cache bust

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -310,7 +310,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func checkForUpdateInBackground() {
         let check = { [weak self] in
             guard let feedURLString = Bundle.main.infoDictionary?["SUFeedURL"] as? String,
-                  let feedURL = URL(string: feedURLString) else { return }
+                  var components = URLComponents(string: feedURLString) else { return }
+            // Cache-bust to bypass GitHub CDN caching
+            components.queryItems = [URLQueryItem(name: "t", value: "\(Int(Date().timeIntervalSince1970))")]
+            guard let feedURL = components.url else { return }
             let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
             var request = URLRequest(url: feedURL)
             request.cachePolicy = .reloadIgnoringLocalCacheData

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -38,6 +38,8 @@
 	<string>HyperPointer converts your speech to text so you can dictate prompts hands-free.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>600</integer>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/jasPreMar/hyper-pointer/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
## Summary
- Set `SUScheduledCheckInterval` to 600s so Sparkle's own automatic checks run every 10 minutes (default was 24 hours), triggering the `didFindValidUpdate` delegate that shows the red dot badge
- Add timestamp query parameter to custom appcast fetch to bypass GitHub CDN caching

## Test plan
- [ ] Merge and release a new version
- [ ] Confirm the red dot appears in the menu bar within ~10 minutes without clicking "Check for Updates" or restarting the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)