### PR TITLE
Change final slide warning color to green

### DIFF
--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -426,7 +426,7 @@ private struct FinishStep: View {
                 }
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.orange.opacity(0.08))
+                .background(Color.green.opacity(0.08))
                 .clipShape(RoundedRectangle(cornerRadius: 14))
             }
             .padding(28)


### PR DESCRIPTION
Change the warning box background color in the final onboarding slide from orange to green for better visual feedback.

This updates the FinishStep component where the "Before you start" warning section is displayed, making it feel more positive and calming.