### PR TITLE
Add inline feedback form popover

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import ApplicationServices
 import Sparkle
+import WebKit
 
 // Global reference for CGEventTap callback (C function pointers can't capture context)
 private weak var sharedAppDelegate: AppDelegate?
@@ -61,6 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var checkForUpdatesItem: NSMenuItem?
     private var updateDot: NSView?
     private var updateCheckTimer: Timer?
+    private var feedbackPopover: NSPopover?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         sharedAppDelegate = self
@@ -209,9 +211,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handleStatusLeaveFeedback() {
-        if let url = URL(string: "https://prickly-perfume-f62.notion.site/5ca57834b3ec456eba024dc6ac60a337?pvs=105") {
-            NSWorkspace.shared.open(url)
+        guard let button = statusItem?.button else { return }
+
+        // Toggle: close if already visible
+        if let existing = feedbackPopover, existing.isShown {
+            existing.performClose(nil)
+            return
         }
+
+        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 580))
+        if let url = URL(string: "https://prickly-perfume-f62.notion.site/ebd/5ca57834b3ec456eba024dc6ac60a337") {
+            webView.load(URLRequest(url: url))
+        }
+
+        let vc = NSViewController()
+        vc.view = webView
+
+        let popover = NSPopover()
+        popover.contentSize = NSSize(width: 480, height: 580)
+        popover.contentViewController = vc
+        popover.behavior = .transient
+        feedbackPopover = popover
+
+        popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
     }
 
     @objc private func handleStatusQuit() {


### PR DESCRIPTION
## Summary
Replaced the Leave Feedback menu item's browser link with an embedded Notion form that appears in a popover window anchored to the menu bar. The form is now accessible directly within the app without leaving to a browser.

## User Experience
- Click "Leave Feedback" to open the popover with the feedback form
- Click again or anywhere outside to dismiss
- Uses native macOS popover styling with transient behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)