### PR TITLE
fix(input): restore key window status after transitioning to chat

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -348,6 +348,10 @@ class FloatingPanel: NSPanel {
             nextOrigin.y = max(sf.minY, min(nextOrigin.y, sf.maxY - frame.height))
         }
         setFrameOrigin(nextOrigin)
+        // Re-establish key window status after the style mask change, which can
+        // silently drop it (non-activating panel → normal titled window).
+        makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
 
         // Switch to chat mode — the PanelContentView handles the rest
         searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query, events: []))


### PR DESCRIPTION
## Summary
Fixed input field becoming unresponsive after starting a chat. When `transitionToTerminal()` changes the window's style mask from a non-activating panel to a normal titled window, macOS silently drops key window status. This prevented the text input from receiving clicks or keyboard input during streaming.

## Changes
Added `makeKeyAndOrderFront(nil)` and `NSApp.activate()` calls after the window geometry is set in `transitionToTerminal()`, matching the pattern used in other show() paths throughout the codebase.

## Test Plan
- Start HyperPointer and submit a message to begin streaming
- Verify the text input remains clickable and accepts keyboard input while streaming
- Verify typing works during and after streaming completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)