### PR TITLE
Show Mac app menu bar when chat window is focused

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -134,18 +134,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // MARK: - Main Menu (key equivalents for text editing)
+    // MARK: - Activation Policy
 
-    /// Registers standard Edit menu key equivalents so that Cmd+A, Cmd+C, Cmd+V, etc.
-    /// are dispatched to the first responder (NSTextView) even though we have no visible menu bar.
+    /// Switches to .regular (menu bar visible) when any chat window is open, otherwise .accessory.
+    func updateActivationPolicy() {
+        let hasChatWindows = panels.contains { $0.isVisible && $0.searchViewModel.isChatMode }
+        NSApp.setActivationPolicy(hasChatWindows ? .regular : .accessory)
+    }
+
+    // MARK: - Main Menu
+
+    /// Registers the app's main menu. This provides standard key equivalents for text editing
+    /// and displays in the Mac menu bar whenever the activation policy is .regular (i.e. a chat
+    /// window is open).
     private func setupMainMenu() {
         let mainMenu = NSMenu()
 
+        // App menu
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+        let appMenu = NSMenu()
+        appMenuItem.submenu = appMenu
+        let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "HyperPointer"
+        appMenu.addItem(NSMenuItem(title: "About \(appName)", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: ""))
+        appMenu.addItem(.separator())
+        let quitItem = NSMenuItem(title: "Quit \(appName)", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenu.addItem(quitItem)
+
+        // Edit menu
         let editMenuItem = NSMenuItem()
         mainMenu.addItem(editMenuItem)
         let editMenu = NSMenu(title: "Edit")
         editMenuItem.submenu = editMenu
-
         editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
         editMenu.addItem(NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
         editMenu.addItem(.separator())
@@ -153,6 +173,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
         editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
         editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+
+        // Window menu
+        let windowMenuItem = NSMenuItem()
+        mainMenu.addItem(windowMenuItem)
+        let windowMenu = NSMenu(title: "Window")
+        windowMenuItem.submenu = windowMenu
+        windowMenu.addItem(NSMenuItem(title: "Minimize", action: #selector(NSWindow.miniaturize(_:)), keyEquivalent: "m"))
+        windowMenu.addItem(NSMenuItem(title: "Close", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w"))
+        NSApp.windowsMenu = windowMenu
 
         NSApp.mainMenu = mainMenu
     }
@@ -298,6 +327,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let panel = FloatingPanel()
         panel.onFeedbackShake = { [weak self] in
             self?.openFeedbackPage()
+        }
+        panel.onChatWindowOpened = { [weak self] in
+            self?.updateActivationPolicy()
+        }
+        panel.onChatWindowClosed = { [weak self] in
+            self?.updateActivationPolicy()
         }
         return panel
     }

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -167,6 +167,8 @@ class FloatingPanel: NSPanel {
     private var mouseShakeDetector = MouseShakeDetector()
     var isCommandKeyHeld = false
     var onFeedbackShake: (() -> Void)?
+    var onChatWindowOpened: (() -> Void)?
+    var onChatWindowClosed: (() -> Void)?
 
     init() {
         super.init(
@@ -371,6 +373,8 @@ class FloatingPanel: NSPanel {
             message: message,
             screenshotURL: screenshotURL
         )
+
+        onChatWindowOpened?()
     }
 
     private func positionAtCursor() {
@@ -571,9 +575,11 @@ class FloatingPanel: NSPanel {
 
         removeAllMonitors()
         voiceController.cancel()
+        let wasTerminalMode = isTerminalMode
         super.close()
         // Restore panel appearance for potential reuse
-        if isTerminalMode {
+        if wasTerminalMode {
+            onChatWindowClosed?()
             styleMask = [.borderless, .nonactivatingPanel]
             level = .screenSaver
             isOpaque = false


### PR DESCRIPTION
## Summary

When a chat window is focused, the Mac app menu bar now appears with the full menu (HyperPointer, Edit, Window). When all chat windows are closed, the app returns to .accessory mode with no menu bar.

## Changes

- Add `updateActivationPolicy()` to AppDelegate that toggles NSApplication activation policy between .regular (menu visible) and .accessory (no menu) based on whether any chat panels are open
- Expand main menu with proper app menu (About, Quit) and add a new Window menu for standard window controls
- Add `onChatWindowOpened` and `onChatWindowClosed` callbacks to FloatingPanel that trigger activation policy updates on chat window lifecycle

This resolves the issue where users expected standard Mac menu bar behavior when interacting with chat windows.