### PR TITLE
fix(streaming): stop button now properly terminates streaming

### DIFF
--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -240,6 +240,7 @@ class ClaudeProcessManager: ObservableObject {
     }
 
     private func handleData(_ data: Data) {
+        guard !isStopped else { return }
         buffer.append(data)
 
         // Split buffer on newlines, process complete lines
@@ -351,17 +352,22 @@ class ClaudeProcessManager: ObservableObject {
     }
     func stop() {
         isStopped = true
-        if let proc = process {
+        if let proc = process, proc.isRunning {
             let pid = proc.processIdentifier
-            // Kill child processes (claude may be a child of the zsh wrapper)
-            let pkillTask = Process()
-            pkillTask.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
-            pkillTask.arguments = ["-KILL", "-P", "\(pid)"]
-            pkillTask.standardOutput = FileHandle.nullDevice
-            pkillTask.standardError = FileHandle.nullDevice
-            try? pkillTask.run()
-            // SIGKILL the main process — cannot be caught or ignored
-            kill(pid, SIGKILL)
+            // Kill child processes first and wait for completion before
+            // killing the parent shell. Without waiting, the shell dies
+            // before pkill runs, orphaning the claude process which keeps
+            // the stdout pipe open and continues streaming.
+            DispatchQueue.global(qos: .userInitiated).async {
+                let pkillTask = Process()
+                pkillTask.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+                pkillTask.arguments = ["-KILL", "-P", "\(pid)"]
+                pkillTask.standardOutput = FileHandle.nullDevice
+                pkillTask.standardError = FileHandle.nullDevice
+                try? pkillTask.run()
+                pkillTask.waitUntilExit()
+                kill(pid, SIGKILL)
+            }
         }
         DispatchQueue.main.async { self.status = .done }
     }


### PR DESCRIPTION
## Summary

Fixed a race condition where clicking the stop button didn't actually stop the streaming output. The issue occurred because `pkillTask.run()` is non-blocking—the parent zsh process was being killed before pkill had a chance to terminate the claude child process, leaving it orphaned with the stdout pipe still open.

Additionally, `handleData()` could process buffered stream data after `isStopped` was set, resetting the status from `.done` back to `.streaming`, making it appear that streaming never actually stopped.

## Changes

- Dispatch the process termination sequence to a background thread and wait for pkill completion before killing the parent
- Add `isStopped` guard to `handleData()` to prevent post-stop UI updates

🤖 Generated with Claude Code