### PR TITLE
Fix onboarding reopen after quitting mid-setup

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -450,7 +450,6 @@ extension AppDelegate: NSWindowDelegate {
             return
         }
         onboardingWindow = nil
-        UserDefaults.standard.set(true, forKey: onboardingSeenKey)
     }
 }
 


### PR DESCRIPTION
Stops marking onboarding as seen when the onboarding window closes. This keeps the wizard from disappearing on the next launch if HyperPointer quits during access grants or other unfinished setup. Explicit finish and skip actions still mark onboarding as complete. Verified with \[0/1] Planning build
Building for debugging...
[0/3] Write swift-version--1AB21518FC5DEDBE.txt
Build complete! (1.80s).