### PR TITLE
Auto-start voice input while Command is held

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ On first launch, HyperPointer opens an onboarding wizard that walks through:
 - Installing or verifying Claude CLI
 - Accessibility
 - Screen Recording
-- Optional microphone and speech permissions for dictation
+- Optional microphone and speech permissions for command-held dictation
 - Optional Automation approvals for the apps you want HyperPointer to control
 
 You can reopen the wizard any time from the menu bar item with `Open Onboarding`.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -89,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return event
         }
 
-        // Hold ⌘ to activate panel; release before sending = dismiss, release after = keep
+        // Hold ⌘ to activate the panel and voice capture; release to anchor the panel for editing.
         flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             self?.handleFlagsChanged(event)
         }

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -151,15 +151,12 @@ class FloatingPanel: NSPanel {
     private var localMouseMonitor: Any?
     private var globalClickMonitor: Any?
     private var commandKeyMouseMonitor: Any?
-    private var globalFlagsMonitor: Any?
-    private var localFlagsMonitor: Any?
     private var dragStartMonitor: Any?
     private var pendingDragEvent: NSEvent?
     private var hostingView: NSHostingView<PanelContentView>!
     private var isTerminalMode = false
     private var isCommandKeyVisible = false
     private var isCursorFollowing = false
-    private var isShiftHeld = false
     private var lastReportedContentSize: CGSize = .zero
     private var focusRestorationState: FocusRestorationState?
     private var shouldRestoreFocusOnClose = true
@@ -209,7 +206,6 @@ class FloatingPanel: NSPanel {
         voiceController.onTranscript = { [weak self] transcript in
             guard let self else { return }
             self.searchViewModel.query = transcript
-            self.searchViewModel.submitMessage()
         }
     }
 
@@ -261,7 +257,6 @@ class FloatingPanel: NSPanel {
     func show(at point: NSPoint) {
         searchViewModel.query = ""
         searchViewModel.updateHoveredApp()
-        installFlagsMonitors()
         isCursorFollowing = false
 
         let fittingSize = hostingView.fittingSize
@@ -293,7 +288,6 @@ class FloatingPanel: NSPanel {
 
     func show() {
         searchViewModel.query = ""
-        installFlagsMonitors()
         isCursorFollowing = true
 
         positionAtCursor()
@@ -445,7 +439,7 @@ class FloatingPanel: NSPanel {
     /// Called when ⌘ is pressed. Shows a minimal icon indicator immediately,
     /// then expands to the full panel on the first cursor move.
     func startCommandKeyMode() {
-        installFlagsMonitors()
+        isCommandKeyHeld = true
         searchViewModel.isCommandKeyMode = true
         searchViewModel.isMinimalMode = true
         searchViewModel.query = ""
@@ -457,6 +451,7 @@ class FloatingPanel: NSPanel {
         searchViewModel.updateHoveredApp()
         positionAtCursor()
         orderFront(nil)
+        startVoiceModeIfNeeded()
 
         commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
             guard let self else { return }
@@ -477,22 +472,13 @@ class FloatingPanel: NSPanel {
         isCursorFollowing = false
         mouseShakeDetector.reset()
 
-        if searchViewModel.isVoiceModeActive {
-            if isShiftHeld {
-                // User is still recording — keep panel open
-                searchViewModel.isCommandKeyMode = false
-                searchViewModel.isMinimalMode = false
-                return
-            } else {
-                // Stale voice state from a quick shift tap — cancel and proceed
-                voiceController.cancel()
-            }
-        }
-
         guard isCommandKeyVisible else {
+            voiceController.cancel()
             dismiss(restorePreviousFocus: false)
             return
         }
+
+        stopVoiceModeIfNeeded()
 
         // Show input row if it was hidden
         if searchViewModel.isCommandKeyMode {
@@ -522,13 +508,14 @@ class FloatingPanel: NSPanel {
         if let m = localMouseMonitor { NSEvent.removeMonitor(m); localMouseMonitor = nil }
         if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
 
-        installFlagsMonitors()
+        isCommandKeyHeld = true
         isCommandKeyVisible = true
         isCursorFollowing = true
         mouseShakeDetector.reset()
         if searchViewModel.query.isEmpty {
             searchViewModel.isCommandKeyMode = true
         }
+        startVoiceModeIfNeeded()
 
         // Global monitor fires when another app is frontmost; local monitor fires when we are.
         commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
@@ -568,8 +555,7 @@ class FloatingPanel: NSPanel {
             localMouseMonitor,
             globalClickMonitor,
             commandKeyMouseMonitor,
-            globalFlagsMonitor,
-            localFlagsMonitor
+            dragStartMonitor
         ].compactMap({ $0 }) {
             NSEvent.removeMonitor(monitor)
         }
@@ -577,8 +563,7 @@ class FloatingPanel: NSPanel {
         localMouseMonitor = nil
         globalClickMonitor = nil
         commandKeyMouseMonitor = nil
-        globalFlagsMonitor = nil
-        localFlagsMonitor = nil
+        dragStartMonitor = nil
         cancelPendingDrag()
         mouseShakeDetector.reset()
     }
@@ -614,7 +599,6 @@ class FloatingPanel: NSPanel {
         isCommandKeyVisible = false
         isCursorFollowing = false
         isCommandKeyHeld = false
-        isShiftHeld = false
 
         if shouldRestoreFocus {
             restoreFocus(using: restorationState)
@@ -636,38 +620,12 @@ class FloatingPanel: NSPanel {
         close()
     }
 
-    private func installFlagsMonitors() {
-        if globalFlagsMonitor == nil {
-            globalFlagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-                self?.handleFlagsChanged(event)
-            }
-        }
-        if localFlagsMonitor == nil {
-            localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-                self?.handleFlagsChanged(event)
-                return event
-            }
-        }
-    }
-
-    private func handleFlagsChanged(_ event: NSEvent) {
-        let shiftDown = event.modifierFlags.contains(.shift)
-
-        if shiftDown && !isShiftHeld {
-            isShiftHeld = true
-            startVoiceModeIfNeeded()
-        } else if !shiftDown && isShiftHeld {
-            isShiftHeld = false
-            stopVoiceModeIfNeeded()
-        }
-    }
-
     private func startVoiceModeIfNeeded() {
         guard isVisible,
               !isTerminalMode,
               !searchViewModel.isChatMode,
-              !searchViewModel.isMinimalMode,
-              isCursorFollowing,
+              isCommandKeyHeld,
+              searchViewModel.isCommandKeyMode,
               !searchViewModel.isVoiceModeActive else { return }
 
         voiceController.start()

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -31,7 +31,7 @@
 	<key>NSDownloadsFolderUsageDescription</key>
 	<string>HyperPointer may access your Downloads folder to help with file management tasks.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>HyperPointer uses your microphone for Shift-to-dictate voice input.</string>
+	<string>HyperPointer uses your microphone for command-held voice input.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>HyperPointer can read and create reminders when you ask it to manage your tasks.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -154,7 +154,7 @@ private struct WelcomeStep: View {
 
                 setupBlock(
                     title: "What is required now",
-                    body: "Claude CLI, Accessibility, and Screen Recording are the core pieces. Microphone and Speech Recognition are only needed for Shift-to-dictate."
+                    body: "Claude CLI, Accessibility, and Screen Recording are the core pieces. Microphone and Speech Recognition are only needed for command-held voice input."
                 )
 
                 HStack(spacing: 12) {
@@ -264,7 +264,7 @@ private struct PermissionsStep: View {
 
                 PermissionRow(
                     title: "Microphone",
-                    description: "Optional. Required only for Shift-to-dictate.",
+                    description: "Optional. Required only for command-held voice input.",
                     statusText: viewModel.statusLabel(for: viewModel.microphoneStatus),
                     isReady: viewModel.microphoneStatus == .authorized,
                     primaryTitle: viewModel.microphoneStatus == .authorized ? "Open Settings" : "Grant Access",

--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -47,7 +47,7 @@ struct SearchView: View {
                         .padding(.horizontal, 8)
                 }
 
-                if !viewModel.isCommandKeyMode && !viewModel.isVoiceModeActive {
+                if !viewModel.isCommandKeyMode {
                     PanelInputRow(
                         viewModel: viewModel,
                         textWidth: $textWidth,
@@ -144,8 +144,6 @@ struct PanelHeaderSection<Accessory: View>: View {
                         text: visiblePart,
                         appIcon: viewModel.hoveredContextIcon,
                         contextText: viewModel.hoveredParts.first,
-                        voiceState: viewModel.voiceState,
-                        voiceLevel: viewModel.voiceLevel,
                         showsCloseButtonOnHover: showsCloseButtonOnHover,
                         onClose: onClose
                     )
@@ -164,7 +162,7 @@ struct PanelHeaderSection<Accessory: View>: View {
                     Group {
                         switch viewModel.voiceState {
                         case .listening:
-                            Text("Release Shift to send")
+                            Text("Release Command to edit")
                                 .font(.system(size: 13))
                                 .foregroundColor(.secondary)
                         case .transcribing:
@@ -183,7 +181,6 @@ struct PanelHeaderSection<Accessory: View>: View {
                     }
 
                     Spacer(minLength: 8)
-                    VoiceTrailingIndicator(state: viewModel.voiceState, level: viewModel.voiceLevel)
                     accessory
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -361,8 +358,6 @@ struct ContextSummaryView: View {
     let text: String
     let appIcon: NSImage?
     let contextText: String?
-    let voiceState: SearchViewModel.VoiceState
-    let voiceLevel: CGFloat
     let showsCloseButtonOnHover: Bool
     let onClose: (() -> Void)?
     @State private var isHovered = false
@@ -377,9 +372,6 @@ struct ContextSummaryView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .foregroundColor(.primary)
-
-            Spacer(minLength: 8)
-            VoiceTrailingIndicator(state: voiceState, level: voiceLevel)
         }
         .frame(maxWidth: .infinity)
         .onHover { isHovered = $0 }
@@ -457,78 +449,6 @@ struct ContextSummaryView: View {
         if lower.contains("notification") { return "bell" }
 
         return "app"
-    }
-}
-
-struct VoiceTrailingIndicator: View {
-    let state: SearchViewModel.VoiceState
-    let level: CGFloat
-
-    var body: some View {
-        Group {
-            switch state {
-            case .idle:
-                HStack(spacing: 3) {
-                    Image(systemName: "shift")
-                        .font(.system(size: 11, weight: .medium))
-                    Image(systemName: "mic")
-                        .font(.system(size: 11, weight: .medium))
-                }
-                .foregroundColor(Color.secondary.opacity(0.45))
-            case .listening:
-                CompactVoiceWaveformView(level: level)
-            case .transcribing:
-                Image(systemName: "ellipsis")
-                    .font(.system(size: 9))
-                    .foregroundColor(.secondary)
-            case .failed:
-                EmptyView()
-            }
-        }
-    }
-}
-
-struct CompactVoiceWaveformView: View {
-    let level: CGFloat
-
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 0.08)) { timeline in
-            let time = timeline.date.timeIntervalSinceReferenceDate
-
-            HStack(alignment: .center, spacing: 2) {
-                ForEach(0..<4, id: \.self) { index in
-                    let phase = abs(sin(time * 6 + Double(index) * 0.65))
-                    let amplitude = max(0.18, min(1, level * (0.75 + (phase * 0.75))))
-
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(Color.accentColor.opacity(0.95))
-                        .frame(width: 3, height: 5 + (amplitude * 14))
-                }
-            }
-            .frame(height: 20, alignment: .center)
-        }
-    }
-}
-
-struct VoiceWaveformView: View {
-    let level: CGFloat
-
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 0.08)) { timeline in
-            let time = timeline.date.timeIntervalSinceReferenceDate
-
-            HStack(alignment: .center, spacing: 3) {
-                ForEach(0..<6, id: \.self) { index in
-                    let phase = abs(sin(time * 6 + Double(index) * 0.65))
-                    let amplitude = max(0.18, min(1, level * (0.75 + (phase * 0.75))))
-
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(Color.accentColor.opacity(0.95))
-                        .frame(width: 3, height: 5 + (amplitude * 14))
-                }
-            }
-            .frame(height: 20, alignment: .center)
-        }
     }
 }
 


### PR DESCRIPTION
Holding Command now starts voice capture immediately, and releasing Command anchors the panel for editing instead of auto-submitting dictated text. The header no longer shows the trailing Shift/mic affordance, and the user-facing copy now refers to command-held voice input in onboarding, README, and Info.plist. Validation: swift build.