### PR TITLE
Restore voice send indicator on Command release

### DIFF
--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -206,6 +206,7 @@ class FloatingPanel: NSPanel {
         voiceController.onTranscript = { [weak self] transcript in
             guard let self else { return }
             self.searchViewModel.query = transcript
+            self.searchViewModel.submitMessage()
         }
     }
 

--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -144,6 +144,8 @@ struct PanelHeaderSection<Accessory: View>: View {
                         text: visiblePart,
                         appIcon: viewModel.hoveredContextIcon,
                         contextText: viewModel.hoveredParts.first,
+                        voiceState: viewModel.voiceState,
+                        voiceLevel: viewModel.voiceLevel,
                         showsCloseButtonOnHover: showsCloseButtonOnHover,
                         onClose: onClose
                     )
@@ -162,7 +164,7 @@ struct PanelHeaderSection<Accessory: View>: View {
                     Group {
                         switch viewModel.voiceState {
                         case .listening:
-                            Text("Release Command to edit")
+                            Text("Release Command to send")
                                 .font(.system(size: 13))
                                 .foregroundColor(.secondary)
                         case .transcribing:
@@ -181,6 +183,7 @@ struct PanelHeaderSection<Accessory: View>: View {
                     }
 
                     Spacer(minLength: 8)
+                    VoiceTrailingIndicator(state: viewModel.voiceState, level: viewModel.voiceLevel)
                     accessory
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -358,6 +361,8 @@ struct ContextSummaryView: View {
     let text: String
     let appIcon: NSImage?
     let contextText: String?
+    let voiceState: SearchViewModel.VoiceState
+    let voiceLevel: CGFloat
     let showsCloseButtonOnHover: Bool
     let onClose: (() -> Void)?
     @State private var isHovered = false
@@ -372,6 +377,9 @@ struct ContextSummaryView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .foregroundColor(.primary)
+
+            Spacer(minLength: 8)
+            VoiceTrailingIndicator(state: voiceState, level: voiceLevel)
         }
         .frame(maxWidth: .infinity)
         .onHover { isHovered = $0 }
@@ -449,6 +457,48 @@ struct ContextSummaryView: View {
         if lower.contains("notification") { return "bell" }
 
         return "app"
+    }
+}
+
+struct VoiceTrailingIndicator: View {
+    let state: SearchViewModel.VoiceState
+    let level: CGFloat
+
+    var body: some View {
+        Group {
+            switch state {
+            case .idle, .failed:
+                EmptyView()
+            case .listening:
+                CompactVoiceWaveformView(level: level)
+            case .transcribing:
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+struct CompactVoiceWaveformView: View {
+    let level: CGFloat
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 0.08)) { timeline in
+            let time = timeline.date.timeIntervalSinceReferenceDate
+
+            HStack(alignment: .center, spacing: 2) {
+                ForEach(0..<4, id: \.self) { index in
+                    let phase = abs(sin(time * 6 + Double(index) * 0.65))
+                    let amplitude = max(0.18, min(1, level * (0.75 + (phase * 0.75))))
+
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(Color.accentColor.opacity(0.95))
+                        .frame(width: 3, height: 5 + (amplitude * 14))
+                }
+            }
+            .frame(height: 20, alignment: .center)
+        }
     }
 }
 


### PR DESCRIPTION
This restores the command-held voice flow so releasing Command after speech submits the dictated prompt again. It also brings back the right-side active voice indicator in the header, including the waveform while listening and the transcribing ellipsis. Validation: swift build.