### PR TITLE
Switch command key trigger from Command to Fn key

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -89,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return event
         }
 
-        // Hold ⌘ to activate the panel and voice capture; release to anchor the panel for editing.
+        // Hold Fn to activate the panel and voice capture; release to anchor the panel for editing.
         flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             self?.handleFlagsChanged(event)
         }
@@ -100,15 +100,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let commandDown = event.modifierFlags.contains(.command)
-        if commandDown && !commandKeyHeld {
+        let fnDown = event.modifierFlags.contains(.function)
+        if fnDown && !commandKeyHeld {
             commandKeyHeld = true
-
-            // Don't enter command-key mode when the user is typing in a chat panel —
-            // let standard Cmd shortcuts (⌘A, ⌘C, ⌘Z, etc.) reach the text field.
-            if panels.first(where: { $0.isVisible && $0.searchViewModel.isChatMode && $0.isKeyWindow }) != nil {
-                return
-            }
 
             // Reuse an existing visible non-chat panel if one exists
             if let existing = panels.first(where: {
@@ -124,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 panels.append(panel)
                 panel.startCommandKeyMode()
             }
-        } else if !commandDown && commandKeyHeld {
+        } else if !fnDown && commandKeyHeld {
             commandKeyHeld = false
             if let panel = commandKeyPanel {
                 panel.isCommandKeyHeld = false

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -437,7 +437,7 @@ class FloatingPanel: NSPanel {
 
     // MARK: - Command key mode
 
-    /// Called when ⌘ is pressed. Shows a minimal icon indicator immediately,
+    /// Called when Fn is pressed. Shows a minimal icon indicator immediately,
     /// then expands to the full panel on the first cursor move.
     func startCommandKeyMode() {
         isCommandKeyHeld = true
@@ -464,7 +464,7 @@ class FloatingPanel: NSPanel {
         }
     }
 
-    /// Called when ⌘ is released. Anchors the panel and shows the input row.
+    /// Called when Fn is released. Anchors the panel and shows the input row.
     /// If the panel was never shown (cursor didn't move), discard silently.
     func endCommandKeyMode() {
         if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
@@ -489,14 +489,14 @@ class FloatingPanel: NSPanel {
             NSApp.activate(ignoringOtherApps: true)
         }
 
-        // Dismiss when cursor moves (unless ⌘ is held again or a message was sent).
+        // Dismiss when cursor moves (unless Fn is held again or a message was sent).
         // Check actual modifier state rather than tracked flag to handle missed releases.
         globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
-            guard let self, !NSEvent.modifierFlags.contains(.command), !self.searchViewModel.isChatMode else { return }
+            guard let self, !NSEvent.modifierFlags.contains(.function), !self.searchViewModel.isChatMode else { return }
             self.dismiss()
         }
         localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
-            guard let self, !NSEvent.modifierFlags.contains(.command), !self.searchViewModel.isChatMode else { return event }
+            guard let self, !NSEvent.modifierFlags.contains(.function), !self.searchViewModel.isChatMode else { return event }
             self.dismiss()
             return event
         }
@@ -531,8 +531,8 @@ class FloatingPanel: NSPanel {
     }
 
     private func handleCommandKeyMouseMove() {
-        // Detect missed ⌘ release (e.g., consumed by App Switcher or Spotlight).
-        if !NSEvent.modifierFlags.contains(.command) {
+        // Detect missed Fn release (e.g., consumed by system).
+        if !NSEvent.modifierFlags.contains(.function) {
             isCommandKeyHeld = false
             onCommandKeyDropped?()
             endCommandKeyMode()


### PR DESCRIPTION
## Summary
Changed the panel activation key from Command (⌘) to Fn key, enabling uninterrupted use of standard Command shortcuts like ⌘A, ⌘C, and ⌘V. The panel still appears immediately when Fn is pressed and expands to full size on first cursor movement.

## Changes
- Updated `handleFlagsChanged()` to detect `.function` modifier instead of `.command`
- Removed the chat-panel guard (specific to Command key interference)
- Updated all modifier flag checks and comments throughout the codebase

🤖 Generated with Claude Code