### PR TITLE
Hide stop button when not streaming

### DIFF
--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -219,7 +219,7 @@ struct PanelInputRow: View {
             .frame(maxWidth: expandsTextField ? .infinity : nil, alignment: .leading)
 
             if let manager = viewModel.claudeManager,
-               manager.status == .waiting || manager.status == .streaming {
+               manager.status == .streaming {
                 Button(action: {
                     manager.stop()
                 }) {


### PR DESCRIPTION
The stop button now only appears while streaming is actually happening, not during the waiting state. After clicking stop to end streaming, the button disappears immediately as the status becomes done.

This provides better UX by only showing the stop button when there's something to stop.