### PR TITLE
Add onboarding setting for invoke hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ On first launch, HyperPointer opens an onboarding wizard that walks through:
 - Installing or verifying Claude CLI
 - Accessibility
 - Screen Recording
-- Optional microphone and speech permissions for command-held dictation
+- Optional microphone and speech permissions for invoke-key dictation
 - Optional Automation approvals for the apps you want HyperPointer to control
 
 You can reopen the wizard any time from the menu bar item with `Open Onboarding`.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -89,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return event
         }
 
-        // Hold Fn to activate the panel and voice capture; release to anchor the panel for editing.
+        // Hold the selected invoke key to activate the panel and voice capture; release to anchor the panel for editing.
         flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             self?.handleFlagsChanged(event)
         }
@@ -100,8 +100,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let fnDown = event.modifierFlags.contains(.function)
-        if fnDown && !commandKeyHeld {
+        let invokeKeyDown = InvokeHotKey.stored().isPressed(in: event.modifierFlags)
+        if invokeKeyDown && !commandKeyHeld {
             commandKeyHeld = true
 
             // Reuse an existing visible non-chat panel if one exists
@@ -118,7 +118,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 panels.append(panel)
                 panel.startCommandKeyMode()
             }
-        } else if !fnDown && commandKeyHeld {
+        } else if !invokeKeyDown && commandKeyHeld {
             commandKeyHeld = false
             if let panel = commandKeyPanel {
                 panel.isCommandKeyHeld = false

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -443,7 +443,7 @@ class FloatingPanel: NSPanel {
 
     // MARK: - Command key mode
 
-    /// Called when Fn is pressed. Shows a minimal icon indicator immediately,
+    /// Called when the invoke hotkey is pressed. Shows a minimal icon indicator immediately,
     /// then expands to the full panel on the first cursor move.
     func startCommandKeyMode() {
         isCommandKeyHeld = true
@@ -470,7 +470,7 @@ class FloatingPanel: NSPanel {
         }
     }
 
-    /// Called when Fn is released. Anchors the panel and shows the input row.
+    /// Called when the invoke hotkey is released. Anchors the panel and shows the input row.
     /// If the panel was never shown (cursor didn't move), discard silently.
     func endCommandKeyMode() {
         if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
@@ -495,14 +495,18 @@ class FloatingPanel: NSPanel {
             NSApp.activate(ignoringOtherApps: true)
         }
 
-        // Dismiss when cursor moves (unless Fn is held again or a message was sent).
+        // Dismiss when cursor moves (unless the invoke hotkey is held again or a message was sent).
         // Check actual modifier state rather than tracked flag to handle missed releases.
         globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
-            guard let self, !NSEvent.modifierFlags.contains(.function), !self.searchViewModel.isChatMode else { return }
+            guard let self,
+                  !InvokeHotKey.stored().isPressed(in: NSEvent.modifierFlags),
+                  !self.searchViewModel.isChatMode else { return }
             self.dismiss()
         }
         localMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
-            guard let self, !NSEvent.modifierFlags.contains(.function), !self.searchViewModel.isChatMode else { return event }
+            guard let self,
+                  !InvokeHotKey.stored().isPressed(in: NSEvent.modifierFlags),
+                  !self.searchViewModel.isChatMode else { return event }
             self.dismiss()
             return event
         }
@@ -537,8 +541,8 @@ class FloatingPanel: NSPanel {
     }
 
     private func handleCommandKeyMouseMove() {
-        // Detect missed Fn release (e.g., consumed by system).
-        if !NSEvent.modifierFlags.contains(.function) {
+        // Detect missed invoke hotkey releases (e.g., consumed by system).
+        if !InvokeHotKey.stored().isPressed(in: NSEvent.modifierFlags) {
             isCommandKeyHeld = false
             onCommandKeyDropped?()
             endCommandKeyMode()

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -31,7 +31,7 @@
 	<key>NSDownloadsFolderUsageDescription</key>
 	<string>HyperPointer may access your Downloads folder to help with file management tasks.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>HyperPointer uses your microphone for command-held voice input.</string>
+	<string>HyperPointer uses your microphone for invoke-key voice input.</string>
 	<key>NSRemindersUsageDescription</key>
 	<string>HyperPointer can read and create reminders when you ask it to manage your tasks.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/Sources/InvokeHotKey.swift
+++ b/Sources/InvokeHotKey.swift
@@ -1,0 +1,75 @@
+import AppKit
+
+enum InvokeHotKey: String, CaseIterable, Identifiable {
+    case function
+    case command
+    case option
+    case control
+
+    static let defaultsKey = "invokeHotKey"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .function:
+            return "Fn"
+        case .command:
+            return "Command"
+        case .option:
+            return "Option"
+        case .control:
+            return "Control"
+        }
+    }
+
+    var holdLabel: String {
+        "Hold \(displayName.lowercased())"
+    }
+
+    var releaseLabel: String {
+        "Release \(displayName.lowercased())"
+    }
+
+    var symbol: String {
+        switch self {
+        case .function:
+            return "fn"
+        case .command:
+            return "\u{2318}"
+        case .option:
+            return "\u{2325}"
+        case .control:
+            return "\u{2303}"
+        }
+    }
+
+    var modifierFlag: NSEvent.ModifierFlags {
+        switch self {
+        case .function:
+            return .function
+        case .command:
+            return .command
+        case .option:
+            return .option
+        case .control:
+            return .control
+        }
+    }
+
+    func isPressed(in flags: NSEvent.ModifierFlags) -> Bool {
+        flags.contains(modifierFlag)
+    }
+
+    func persist(in defaults: UserDefaults = .standard) {
+        defaults.set(rawValue, forKey: Self.defaultsKey)
+    }
+
+    static func stored(in defaults: UserDefaults = .standard) -> InvokeHotKey {
+        guard let rawValue = defaults.string(forKey: defaultsKey),
+              let hotKey = InvokeHotKey(rawValue: rawValue) else {
+            return .function
+        }
+        return hotKey
+    }
+}

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -154,7 +154,7 @@ private struct WelcomeStep: View {
 
                 setupBlock(
                     title: "What is required now",
-                    body: "Claude CLI, Accessibility, and Screen Recording are the core pieces. Microphone and Speech Recognition are only needed for command-held voice input."
+                    body: "Claude CLI, Accessibility, and Screen Recording are the core pieces. Microphone and Speech Recognition are only needed for invoke-key voice input."
                 )
 
                 HStack(spacing: 12) {
@@ -264,7 +264,7 @@ private struct PermissionsStep: View {
 
                 PermissionRow(
                     title: "Microphone",
-                    description: "Optional. Required only for command-held voice input.",
+                    description: "Optional. Required only if you want voice input while holding your invoke key.",
                     statusText: viewModel.statusLabel(for: viewModel.microphoneStatus),
                     isReady: viewModel.microphoneStatus == .authorized,
                     primaryTitle: viewModel.microphoneStatus == .authorized ? "Open Settings" : "Grant Access",
@@ -281,7 +281,7 @@ private struct PermissionsStep: View {
 
                 PermissionRow(
                     title: "Speech Recognition",
-                    description: "Optional. Used together with the microphone for voice input.",
+                    description: "Optional. Used together with the microphone for invoke-key voice input.",
                     statusText: viewModel.statusLabel(for: viewModel.speechStatus),
                     isReady: viewModel.speechStatus == .authorized,
                     primaryTitle: viewModel.speechStatus == .authorized ? "Open Settings" : "Grant Access",
@@ -439,20 +439,20 @@ private class TutorialState: ObservableObject {
     }
 
     private func handleFlags(_ event: NSEvent) {
-        let commandDown = event.modifierFlags.contains(.command)
+        let invokeKeyDown = InvokeHotKey.stored().isPressed(in: event.modifierFlags)
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             switch self.phase {
             case .holdCommand:
-                if commandDown { self.phase = .exploring }
+                if invokeKeyDown { self.phase = .exploring }
             case .exploring, .hovering:
-                if !commandDown {
+                if !invokeKeyDown {
                     self.dwellTimer?.invalidate()
                     self.phase = .holdCommand
                     self.hoveredItem = nil
                 }
             case .dwelled:
-                if !commandDown {
+                if !invokeKeyDown {
                     self.selectedItem = self.hoveredItem
                     self.phase = .released
                 }
@@ -490,20 +490,49 @@ private struct FinishStep: View {
     @StateObject private var tutorial = TutorialState()
 
     var body: some View {
-        ZStack {
-            if tutorial.phase == .holdCommand {
-                holdCommandView
-                    .transition(.opacity)
-            } else {
-                desktopView
-                    .transition(.opacity)
+        VStack(spacing: 0) {
+            invokeKeyCard
+
+            ZStack {
+                if tutorial.phase == .holdCommand {
+                    holdCommandView
+                        .transition(.opacity)
+                } else {
+                    desktopView
+                        .transition(.opacity)
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.easeOut(duration: 0.3), value: tutorial.phase)
         .animation(.easeOut(duration: 0.15), value: tutorial.hoveredItem?.id)
         .onAppear { tutorial.start() }
         .onDisappear { tutorial.stop() }
+    }
+
+    private var invokeKeyCard: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Invoke hotkey")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Choose which modifier key you hold to bring up HyperPointer. Fn is the safest default if you want to avoid clashes with app shortcuts.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Picker("Invoke hotkey", selection: $viewModel.invokeHotKey) {
+                ForEach(InvokeHotKey.allCases) { hotKey in
+                    Text(hotKey.displayName).tag(hotKey)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 160)
+        }
+        .padding(.horizontal, 28)
+        .padding(.top, 24)
+        .padding(.bottom, 12)
     }
 
     // MARK: - Hold Command Phase
@@ -511,10 +540,10 @@ private struct FinishStep: View {
     private var holdCommandView: some View {
         VStack(spacing: 16) {
             Spacer()
-            Text("\u{2318}")
+            Text(viewModel.invokeHotKey.symbol)
                 .font(.system(size: 56, weight: .medium, design: .rounded))
                 .foregroundStyle(.tertiary)
-            Text("Hold command")
+            Text(viewModel.invokeHotKey.holdLabel)
                 .font(.system(size: 24, weight: .semibold))
             Text("You should see a little icon appear next to your cursor.")
                 .font(.system(size: 14))
@@ -586,7 +615,7 @@ private struct FinishStep: View {
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                 case .dwelled:
-                    Text("Now release \u{2318}")
+                    Text(viewModel.invokeHotKey.releaseLabel)
                         .font(.system(size: 14, weight: .medium))
                     Text("The panel will anchor and an input field will appear.")
                         .font(.system(size: 12))

--- a/Sources/OnboardingViewModel.swift
+++ b/Sources/OnboardingViewModel.swift
@@ -17,6 +17,12 @@ struct AutomationApp: Identifiable {
 
 final class OnboardingViewModel: ObservableObject {
     @Published var currentStep = 0
+    @Published var invokeHotKey = InvokeHotKey.stored() {
+        didSet {
+            guard oldValue != invokeHotKey else { return }
+            invokeHotKey.persist()
+        }
+    }
     @Published var isClaudeInstalled = false
     @Published var isAccessibilityGranted = false
     @Published var isScreenRecordingGranted = false
@@ -57,6 +63,7 @@ final class OnboardingViewModel: ObservableObject {
     }
 
     func refresh() {
+        invokeHotKey = InvokeHotKey.stored()
         isClaudeInstalled = resolveClaudeBinaryPath() != nil
         isAccessibilityGranted = AXIsProcessTrusted()
         isScreenRecordingGranted = CGPreflightScreenCaptureAccess()


### PR DESCRIPTION
## Summary
Adds a persisted invoke hotkey preference so the panel no longer has to be tied to fn.
Updates onboarding to let users choose the modifier key, reflects that choice in the tutorial copy, and warns that fn is the safest default.
Wires the selected key through the app delegate and floating panel release logic, and updates the related docs and permission copy.

## Verification
swift build