### PR TITLE
Add chime sound toggle to onboarding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
             ],
             path: "Sources",
             exclude: ["Info.plist"],
+            resources: [
+                .process("Resources/A4.wav"),
+                .process("Resources/C5.wav"),
+            ],
             // Embed Info.plist so macOS shows proper privacy descriptions in TCC dialogs.
             // Run `swift build` from the package root so the relative path resolves correctly.
             linkerSettings: [

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -67,6 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         sharedAppDelegate = self
+        UserDefaults.standard.register(defaults: ["chimeEnabled": true])
         setupMainMenu()
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
         setupStatusItem()
@@ -104,7 +105,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let invokeKeyDown = InvokeHotKey.stored().isPressed(in: event.modifierFlags)
         if invokeKeyDown && !commandKeyHeld {
             commandKeyHeld = true
-            soundPlayer.playPress()
+            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
+                soundPlayer.playPress()
+            }
 
             // Reuse an existing visible non-chat panel if one exists
             if let existing = panels.first(where: {
@@ -122,7 +125,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } else if !invokeKeyDown && commandKeyHeld {
             commandKeyHeld = false
-            soundPlayer.playRelease()
+            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
+                soundPlayer.playRelease()
+            }
             if let panel = commandKeyPanel {
                 panel.isCommandKeyHeld = false
                 panel.endCommandKeyMode()
@@ -333,7 +338,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.openFeedbackPage()
         }
         panel.onMessageSent = { [weak self] in
-            self?.soundPlayer.playRelease()
+            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
+                self?.soundPlayer.playRelease()
+            }
         }
         return panel
     }

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -570,6 +570,9 @@ private struct FinishStep: View {
                 invokeKeyCard
                     .cardStyle()
 
+                chimeToggleCard
+                    .cardStyle()
+
                 ZStack {
                     if tutorial.phase == .holdCommand {
                         holdCommandView
@@ -611,6 +614,30 @@ private struct FinishStep: View {
             .pickerStyle(.menu)
             .frame(width: 160)
             .onboardingClickableCursor()
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 18)
+    }
+
+    private var chimeToggleCard: some View {
+        HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Chime sound")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("Play a chime when you press and release the invoke key.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $viewModel.chimeEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onboardingClickableCursor()
+                .onChange(of: viewModel.chimeEnabled) { _, enabled in
+                    if enabled { viewModel.soundPlayer.playPress() }
+                }
         }
         .padding(.horizontal, 28)
         .padding(.vertical, 18)

--- a/Sources/OnboardingViewModel.swift
+++ b/Sources/OnboardingViewModel.swift
@@ -27,6 +27,7 @@ private enum PendingPermissionRequest: String {
 
 final class OnboardingViewModel: ObservableObject {
     private static let currentStepKey = "onboardingCurrentStep"
+    let soundPlayer = PTTSoundPlayer()
     private static let lastStepIndex = 3
     private static let resumeOnLaunchKey = "resumeOnboardingOnLaunch"
     private static let pendingPermissionRequestKey = "pendingPermissionRequest"
@@ -41,6 +42,11 @@ final class OnboardingViewModel: ObservableObject {
         didSet {
             guard oldValue != invokeHotKey else { return }
             invokeHotKey.persist()
+        }
+    }
+    @Published var chimeEnabled = UserDefaults.standard.bool(forKey: "chimeEnabled") {
+        didSet {
+            UserDefaults.standard.set(chimeEnabled, forKey: "chimeEnabled")
         }
     }
     @Published var isClaudeInstalled = false

--- a/Sources/PTTSoundPlayer.swift
+++ b/Sources/PTTSoundPlayer.swift
@@ -23,12 +23,9 @@ class PTTSoundPlayer {
     }
 
     private static func loadSound(named name: String) -> NSSound? {
-        if let url = Bundle.main.url(forResource: name, withExtension: "wav") {
+        if let url = Bundle.module.url(forResource: name, withExtension: "wav") {
             return NSSound(contentsOf: url, byReference: false)
         }
-        let execDir = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent()
-        let url = execDir.appendingPathComponent("\(name).wav")
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        return NSSound(contentsOf: url, byReference: false)
+        return nil
     }
 }


### PR DESCRIPTION
Adds a toggle switch in the onboarding wizard's final step to let users control whether chime sounds play when they press and release the invoke key.

**Changes:**
- New toggle switch below the invoke hotkey setting
- Preview sound plays when toggled on
- Preference is stored in UserDefaults (defaults to enabled)
- Fixed PTTSoundPlayer to properly load resources from SPM bundle
- Declared audio resources in Package.swift

Users can disable chimes while keeping the core functionality intact.