### PR TITLE
Add Developer ID notarization flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,56 +56,80 @@ jobs:
         run: swift package resolve
 
       # -----------------------------------------------------------------------
-      # Code signing — import a self-signed cert so TCC permissions survive
-      # Sparkle updates. Without a stable signature, each new binary gets a
-      # new ad-hoc hash and macOS re-prompts for every permission on first launch.
+      # Distribution signing — Gatekeeper only shows the normal
+      # "downloaded from the Internet" prompt when the build is signed with a
+      # real Developer ID Application certificate and notarized by Apple.
       #
-      # One-time setup (run scripts/create-signing-cert.sh, then store outputs):
-      #   SIGNING_CERT_P12          — base64-encoded .p12 file
-      #   SIGNING_CERT_PASSWORD     — password used when exporting the .p12
-      #   SIGNING_CERT_NAME         — Common Name of the cert (e.g. "HyperPointer")
+      # Required repository secrets:
+      #   DEVELOPER_ID_APPLICATION_P12
+      #   DEVELOPER_ID_APPLICATION_PASSWORD
+      #   DEVELOPER_ID_APPLICATION_NAME
+      #   APPLE_ID
+      #   APPLE_TEAM_ID
+      #   APPLE_APP_SPECIFIC_PASSWORD
       # -----------------------------------------------------------------------
-      - name: Import signing certificate
+      - name: Import Developer ID Application certificate
         id: signing
         env:
-          SIGNING_CERT_P12:      ${{ secrets.SIGNING_CERT_P12 }}
-          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
-          SIGNING_CERT_NAME:     ${{ secrets.SIGNING_CERT_NAME }}
+          SIGNING_CERT_P12:      ${{ secrets.DEVELOPER_ID_APPLICATION_P12 }}
+          SIGNING_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
+          SIGNING_CERT_NAME:     ${{ secrets.DEVELOPER_ID_APPLICATION_NAME }}
         run: |
           if [[ -z "${SIGNING_CERT_P12:-}" ]]; then
-            echo "SIGNING_CERT_P12 not set — falling back to ad-hoc signing."
-            echo "sign_mode=ad-hoc"    >> "$GITHUB_OUTPUT"
-            echo "sign_identity="      >> "$GITHUB_OUTPUT"
-          else
-            KEYCHAIN=build.keychain
-            security create-keychain -p "" "$KEYCHAIN"
-            security default-keychain -s "$KEYCHAIN"
-            security unlock-keychain -p "" "$KEYCHAIN"
-            security set-keychain-settings -t 3600 -u "$KEYCHAIN"
-
-            echo "$SIGNING_CERT_P12" | base64 --decode > /tmp/signing.p12
-            security import /tmp/signing.p12 -k "$KEYCHAIN" \
-              -P "$SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
-            rm /tmp/signing.p12
-
-            security set-key-partition-list \
-              -S "apple-tool:,apple:,codesign:" -s -k "" "$KEYCHAIN"
-
-            echo "sign_mode=identity"             >> "$GITHUB_OUTPUT"
-            echo "sign_identity=$SIGNING_CERT_NAME" >> "$GITHUB_OUTPUT"
-            echo "Imported certificate: $SIGNING_CERT_NAME"
+            echo "DEVELOPER_ID_APPLICATION_P12 is not configured." >&2
+            exit 1
           fi
+
+          KEYCHAIN=build.keychain
+          security create-keychain -p "" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "" "$KEYCHAIN"
+          security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+
+          echo "$SIGNING_CERT_P12" | base64 --decode > /tmp/signing.p12
+          security import /tmp/signing.p12 -k "$KEYCHAIN" \
+            -P "$SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
+          rm /tmp/signing.p12
+
+          security set-key-partition-list \
+            -S "apple-tool:,apple:,codesign:" -s -k "" "$KEYCHAIN"
+
+          echo "sign_identity=$SIGNING_CERT_NAME" >> "$GITHUB_OUTPUT"
+          echo "Imported certificate: $SIGNING_CERT_NAME"
+
+      - name: Build app bundle
+        env:
+          SIGN_IDENTITY: ${{ steps.signing.outputs.sign_identity }}
+        run: |
+          ./scripts/build-app.sh \
+            --sign-mode developer-id \
+            --sign-identity "$SIGN_IDENTITY"
+
+      - name: Notarize app bundle
+        env:
+          APPLE_ID:                    ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:               ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          ./scripts/notarize.sh --path dist/HyperPointer.app
 
       - name: Build DMG
         env:
-          SIGN_MODE:     ${{ steps.signing.outputs.sign_mode }}
           SIGN_IDENTITY: ${{ steps.signing.outputs.sign_identity }}
         run: |
-          ARGS=(--sign-mode "$SIGN_MODE")
-          if [[ -n "$SIGN_IDENTITY" ]]; then
-            ARGS+=(--sign-identity "$SIGN_IDENTITY")
-          fi
-          ./scripts/build-dmg.sh "${ARGS[@]}"
+          ./scripts/build-dmg.sh \
+            --skip-build \
+            --app-path dist/HyperPointer.app \
+            --sign-mode developer-id \
+            --sign-identity "$SIGN_IDENTITY"
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID:                    ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:               ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          ./scripts/notarize.sh --path dist/HyperPointer.dmg
 
       - name: Collect DMG metadata
         id: dmg

--- a/MACOS_GATEKEEPER_NOTARIZATION_CHECKLIST.md
+++ b/MACOS_GATEKEEPER_NOTARIZATION_CHECKLIST.md
@@ -1,0 +1,112 @@
+# macOS Gatekeeper And Notarization Checklist
+
+## Goal
+
+Ship HyperPointer so users see the normal:
+
+- "This app was downloaded from the Internet. Are you sure you want to open it?"
+
+Instead of the blocking warning:
+
+- "macOS can't confirm this app is free from malware"
+
+## What Causes The Difference
+
+To get the normal first-open prompt for a downloaded DMG, the release needs:
+
+1. A real `Developer ID Application` certificate
+2. Hardened runtime enabled
+3. Apple notarization
+4. Stapling the notarization ticket to the `.app` and `.dmg`
+
+Ad-hoc signing and self-signed certificates are fine for local testing, but they do not remove the Gatekeeper malware warning for other Macs.
+
+## Current Status
+
+- Repo packaging and release workflow have been updated for Developer ID signing and notarization.
+- Apple Developer account approval is still pending.
+- Actual certificate creation and notarization are blocked until Apple finishes account activation.
+
+## Files Already Added Or Updated
+
+- `scripts/build-app.sh`
+- `scripts/build-dmg.sh`
+- `scripts/notarize.sh`
+- `config/macos/distribution.entitlements`
+- `.github/workflows/release.yml`
+- `README.md`
+
+## GitHub Secrets Needed
+
+- `DEVELOPER_ID_APPLICATION_P12`
+- `DEVELOPER_ID_APPLICATION_PASSWORD`
+- `DEVELOPER_ID_APPLICATION_NAME`
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `SPARKLE_PRIVATE_KEY`
+
+## What To Do While Waiting For Apple Approval
+
+1. Confirm the Apple ID you will use for notarization has 2FA enabled.
+2. Decide whether CI will use:
+   - Apple ID + app-specific password
+   - App Store Connect API key + `notarytool` keychain profile
+3. Create the GitHub secret placeholders listed above.
+4. Generate or verify the Sparkle signing keypair.
+5. Keep testing local `.app` and `.dmg` builds.
+
+## Release Flow Once Apple Approves The Account
+
+1. Create or download the `Developer ID Application` certificate.
+2. Export it as a `.p12`.
+3. Add the Apple and certificate secrets to GitHub.
+4. Build the app with Developer ID signing.
+5. Notarize and staple the `.app`.
+6. Build the DMG from the stapled app.
+7. Notarize and staple the `.dmg`.
+8. Publish the release.
+
+## Local Commands
+
+Build app bundle locally:
+
+```bash
+./scripts/build-app.sh --sign-mode skip
+```
+
+Build DMG from an existing local app:
+
+```bash
+./scripts/build-dmg.sh --skip-build --app-path dist/HyperPointer.app --sign-mode skip
+```
+
+Developer ID + notarization flow:
+
+```bash
+./scripts/build-app.sh \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.app \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
+
+./scripts/build-dmg.sh \
+  --skip-build \
+  --app-path dist/HyperPointer.app \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.dmg \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
+```
+
+## One-Line Summary
+
+There is no public shortcut around Apple's process: to move from the malware block to the normal first-open prompt, HyperPointer must ship as a Developer ID signed, notarized, stapled macOS release.

--- a/README.md
+++ b/README.md
@@ -121,11 +121,35 @@ sudo make grant
 
 This writes the grants directly to the TCC database so no popups ever appear.
 
-The `.app` and `.dmg` targets default to ad-hoc signing so they work cleanly on the local machine. If you want a distributable artifact for other Macs, pass a real Developer ID identity and notarize the result:
+The `.app` and `.dmg` targets default to ad-hoc signing so they work cleanly on the local machine. That is enough for local testing, but it still triggers Gatekeeper's "macOS can't verify this app is free from malware" block on other Macs.
+
+To get the normal "This app was downloaded from the Internet" prompt instead, ship a Developer ID signed and notarized build:
 
 ```bash
-SIGN_MODE=identity SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" make dmg
+./scripts/build-app.sh \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.app \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
+
+./scripts/build-dmg.sh \
+  --skip-build \
+  --app-path dist/HyperPointer.app \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.dmg \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
 ```
+
+The release workflow now follows that sequence automatically when the required GitHub secrets are configured.
 
 ## Sparkle Release Signing
 
@@ -145,6 +169,15 @@ That command prints the public key to embed in `SUPublicEDKey` inside `Sources/I
 ```
 
 Copy the contents of `sparkle-private-key.txt` into the `SPARKLE_PRIVATE_KEY` GitHub secret, then delete the file. The release workflow reads that secret with `sign_update --ed-key-file -`, signs `dist/HyperPointer.dmg`, and writes the resulting signature into `appcast.xml`.
+
+For public macOS releases you also need these GitHub secrets:
+
+- `DEVELOPER_ID_APPLICATION_P12`
+- `DEVELOPER_ID_APPLICATION_PASSWORD`
+- `DEVELOPER_ID_APPLICATION_NAME`
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
 
 ## Usage
 

--- a/config/macos/distribution.entitlements
+++ b/config/macos/distribution.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -10,6 +10,7 @@ INSTALL_AFTER_BUILD=0
 RUN_AFTER_BUILD=0
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 SIGN_MODE="ad-hoc"
+ENTITLEMENTS_PATH="${ENTITLEMENTS_PATH:-$ROOT_DIR/config/macos/distribution.entitlements}"
 
 usage() {
   cat <<EOF
@@ -21,8 +22,9 @@ Options:
   --install                        Copy the built app into /Applications
   --run                            Open the built app after packaging
   --sign-identity <identity>       macOS signing identity to use
-  --sign-mode <ad-hoc|identity|skip>
+  --sign-mode <ad-hoc|identity|developer-id|skip>
                                    Signing mode (default: ad-hoc)
+  --entitlements <path>            Entitlements plist for Developer ID signing
 EOF
 }
 
@@ -53,6 +55,10 @@ while [[ $# -gt 0 ]]; do
       SIGN_MODE="${2:?missing value for --sign-mode}"
       shift 2
       ;;
+    --entitlements)
+      ENTITLEMENTS_PATH="${2:?missing value for --entitlements}"
+      shift 2
+      ;;
     --help|-h)
       usage
       exit 0
@@ -66,7 +72,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SIGN_MODE" in
-  ad-hoc|identity|skip)
+  ad-hoc|identity|developer-id|skip)
     ;;
   *)
     echo "Unsupported sign mode: $SIGN_MODE" >&2
@@ -77,6 +83,18 @@ esac
 if [[ "$SIGN_MODE" == "identity" && -z "$SIGN_IDENTITY" ]]; then
   echo "--sign-mode identity requires --sign-identity." >&2
   exit 1
+fi
+
+if [[ "$SIGN_MODE" == "developer-id" && -z "$SIGN_IDENTITY" ]]; then
+  echo "--sign-mode developer-id requires --sign-identity." >&2
+  exit 1
+fi
+
+if [[ "$SIGN_MODE" == "developer-id" ]]; then
+  if [[ ! -f "$ENTITLEMENTS_PATH" ]]; then
+    echo "Developer ID signing requires an entitlements plist at: $ENTITLEMENTS_PATH" >&2
+    exit 1
+  fi
 fi
 
 cd "$ROOT_DIR"
@@ -108,25 +126,39 @@ if [[ "$SIGN_MODE" != "skip" ]]; then
 
   if [[ "$SIGN_MODE" == "identity" ]]; then
     SIGN_ARG="$SIGN_IDENTITY"
+    TIMESTAMP_ARGS=(--timestamp=none)
+    SIGN_COMMON_ARGS=()
+    ENTITLEMENT_ARGS=()
+  elif [[ "$SIGN_MODE" == "developer-id" ]]; then
+    SIGN_ARG="$SIGN_IDENTITY"
+    TIMESTAMP_ARGS=(--timestamp)
+    SIGN_COMMON_ARGS=(--options runtime)
+    ENTITLEMENT_ARGS=(--entitlements "$ENTITLEMENTS_PATH")
   else
     SIGN_ARG="-"
+    TIMESTAMP_ARGS=(--timestamp=none)
+    SIGN_COMMON_ARGS=()
+    ENTITLEMENT_ARGS=()
   fi
 
   # Sign nested components before the app bundle
   if [[ -d "$CONTENTS_PATH/Frameworks/Sparkle.framework" ]]; then
     # Sign XPC services inside Sparkle
     find "$CONTENTS_PATH/Frameworks/Sparkle.framework" -name "*.xpc" -type d | while read xpc; do
-      codesign --force --sign "$SIGN_ARG" --timestamp=none "$xpc"
+      codesign --force --sign "$SIGN_ARG" "${TIMESTAMP_ARGS[@]}" "${SIGN_COMMON_ARGS[@]}" "$xpc"
     done
-    codesign --force --sign "$SIGN_ARG" --timestamp=none "$CONTENTS_PATH/Frameworks/Sparkle.framework"
+    codesign --force --sign "$SIGN_ARG" "${TIMESTAMP_ARGS[@]}" "${SIGN_COMMON_ARGS[@]}" "$CONTENTS_PATH/Frameworks/Sparkle.framework"
   fi
 
   codesign \
     --force \
-    --deep \
     --sign "$SIGN_ARG" \
-    --timestamp=none \
+    "${TIMESTAMP_ARGS[@]}" \
+    "${SIGN_COMMON_ARGS[@]}" \
+    "${ENTITLEMENT_ARGS[@]}" \
     "$APP_PATH"
+
+  codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 fi
 
 echo "Built app bundle: $APP_PATH"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -10,6 +10,7 @@ DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
 VOLUME_NAME="${DMG_VOLUME_NAME:-$APP_NAME}"
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 SIGN_MODE="${SIGN_MODE:-ad-hoc}"
+SKIP_BUILD=0
 TEMP_DIR="$(mktemp -d)"
 STAGING_DIR="$TEMP_DIR/staging"
 RW_DMG_PATH="$TEMP_DIR/$APP_NAME-rw.dmg"
@@ -26,10 +27,12 @@ Usage: $(basename "$0") [options]
 Options:
   --configuration <debug|release>  Build configuration (default: release)
   --output-dir <path>              Artifact directory (default: ./dist)
+  --app-path <path>                Existing app bundle to package (default: ./dist/HyperPointer.app)
   --volume-name <name>             Mounted DMG volume name (default: HyperPointer)
   --sign-identity <identity>       macOS signing identity to use for the app build
-  --sign-mode <ad-hoc|identity|skip>
+  --sign-mode <ad-hoc|identity|developer-id|skip>
                                    Signing mode passed through to build-app.sh
+  --skip-build                     Package the existing app bundle without rebuilding it
 EOF
 }
 
@@ -45,6 +48,10 @@ while [[ $# -gt 0 ]]; do
       DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
       shift 2
       ;;
+    --app-path)
+      APP_PATH="${2:?missing value for --app-path}"
+      shift 2
+      ;;
     --volume-name)
       VOLUME_NAME="${2:?missing value for --volume-name}"
       shift 2
@@ -56,6 +63,10 @@ while [[ $# -gt 0 ]]; do
     --sign-mode)
       SIGN_MODE="${2:?missing value for --sign-mode}"
       shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
       ;;
     --help|-h)
       usage
@@ -69,6 +80,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "$SIGN_MODE" in
+  ad-hoc|identity|developer-id|skip)
+    ;;
+  *)
+    echo "Unsupported sign mode: $SIGN_MODE" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$SIGN_MODE" == "developer-id" && -z "$SIGN_IDENTITY" ]]; then
+  echo "--sign-mode developer-id requires --sign-identity." >&2
+  exit 1
+fi
+
 mkdir -p "$DIST_DIR" "$STAGING_DIR"
 
 build_app_args=(
@@ -81,7 +106,14 @@ if [[ -n "$SIGN_IDENTITY" ]]; then
   build_app_args+=(--sign-identity "$SIGN_IDENTITY")
 fi
 
-"$ROOT_DIR/scripts/build-app.sh" "${build_app_args[@]}"
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  "$ROOT_DIR/scripts/build-app.sh" "${build_app_args[@]}"
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "App bundle not found: $APP_PATH" >&2
+  exit 1
+fi
 
 ditto "$APP_PATH" "$STAGING_DIR/$APP_NAME.app"
 ln -s /Applications "$STAGING_DIR/Applications"
@@ -101,5 +133,10 @@ hdiutil convert \
   -format UDZO \
   -imagekey zlib-level=9 \
   -o "$DMG_PATH"
+
+if [[ "$SIGN_MODE" == "developer-id" ]]; then
+  codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG_PATH"
+  codesign --verify --verbose=2 "$DMG_PATH"
+fi
 
 echo "Built installer image: $DMG_PATH"

--- a/scripts/create-signing-cert.sh
+++ b/scripts/create-signing-cert.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # One-time setup: create a self-signed code-signing certificate and export it
-# so CI can import it for stable signing.
+# so CI or local builds can keep a stable signature for TCC permissions.
 #
 # Usage: ./scripts/create-signing-cert.sh [cert-name]
 #   cert-name defaults to "HyperPointer"
@@ -16,6 +16,11 @@
 #   re-prompts for all permissions. A stable self-signed cert produces a
 #   requirement tied to the cert anchor hash — stable across all builds
 #   signed with the same cert.
+#
+# Important:
+#   This is not a replacement for Developer ID signing and notarization.
+#   A self-signed cert will not remove Gatekeeper's malware warning on
+#   downloaded apps.
 set -euo pipefail
 
 CERT_NAME="${1:-HyperPointer}"

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,122 @@
+#!/bin/zsh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_PATH=""
+APPLE_ID="${APPLE_ID:-}"
+TEAM_ID="${APPLE_TEAM_ID:-${TEAM_ID:-}}"
+APP_PASSWORD="${APPLE_APP_SPECIFIC_PASSWORD:-${APP_PASSWORD:-}}"
+KEYCHAIN_PROFILE="${NOTARYTOOL_KEYCHAIN_PROFILE:-}"
+TEMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --path <path>                    App bundle, DMG, PKG, or ZIP to notarize
+  --apple-id <email>              Apple ID for notarytool authentication
+  --team-id <team-id>             Apple Developer Team ID
+  --password <app-password>       App-specific password for the Apple ID
+  --keychain-profile <profile>    Stored notarytool keychain profile to use instead
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path)
+      TARGET_PATH="${2:?missing value for --path}"
+      shift 2
+      ;;
+    --apple-id)
+      APPLE_ID="${2:?missing value for --apple-id}"
+      shift 2
+      ;;
+    --team-id)
+      TEAM_ID="${2:?missing value for --team-id}"
+      shift 2
+      ;;
+    --password)
+      APP_PASSWORD="${2:?missing value for --password}"
+      shift 2
+      ;;
+    --keychain-profile)
+      KEYCHAIN_PROFILE="${2:?missing value for --keychain-profile}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET_PATH" ]]; then
+  echo "--path is required." >&2
+  exit 1
+fi
+
+if [[ ! -e "$TARGET_PATH" ]]; then
+  echo "Notarization target not found: $TARGET_PATH" >&2
+  exit 1
+fi
+
+AUTH_ARGS=()
+if [[ -n "$KEYCHAIN_PROFILE" ]]; then
+  AUTH_ARGS=(--keychain-profile "$KEYCHAIN_PROFILE")
+else
+  if [[ -z "$APPLE_ID" || -z "$TEAM_ID" || -z "$APP_PASSWORD" ]]; then
+    echo "Provide either --keychain-profile or all of --apple-id, --team-id, and --password." >&2
+    exit 1
+  fi
+  AUTH_ARGS=(--apple-id "$APPLE_ID" --team-id "$TEAM_ID" --password "$APP_PASSWORD")
+fi
+
+ABS_TARGET_PATH="$(cd "$(dirname "$TARGET_PATH")" && pwd)/$(basename "$TARGET_PATH")"
+SUBMIT_PATH="$ABS_TARGET_PATH"
+STAPLE_PATH="$ABS_TARGET_PATH"
+
+case "$ABS_TARGET_PATH" in
+  *.app)
+    ZIP_PATH="$TEMP_DIR/$(basename "$ABS_TARGET_PATH").zip"
+    ditto -c -k --keepParent "$ABS_TARGET_PATH" "$ZIP_PATH"
+    SUBMIT_PATH="$ZIP_PATH"
+    ;;
+  *.dmg|*.pkg)
+    ;;
+  *.zip)
+    STAPLE_PATH=""
+    ;;
+  *)
+    echo "Unsupported notarization target: $ABS_TARGET_PATH" >&2
+    exit 1
+    ;;
+esac
+
+xcrun notarytool submit "$SUBMIT_PATH" "${AUTH_ARGS[@]}" --wait
+
+if [[ -n "$STAPLE_PATH" ]]; then
+  xcrun stapler staple "$STAPLE_PATH"
+  xcrun stapler validate "$STAPLE_PATH"
+fi
+
+case "$ABS_TARGET_PATH" in
+  *.app)
+    spctl -a -vvv --type exec "$ABS_TARGET_PATH"
+    ;;
+  *.dmg)
+    spctl -a -vvv -t open "$ABS_TARGET_PATH"
+    ;;
+esac
+
+echo "Notarized: $ABS_TARGET_PATH"


### PR DESCRIPTION
## Summary
- switch the release workflow from ad-hoc/self-signed distribution to Developer ID signing plus app and DMG notarization
- add reusable packaging support for developer-id signing, stapling, and DMG creation from a pre-notarized app bundle
- document the Gatekeeper warning difference, required GitHub secrets, and the release checklist for finishing setup once Apple approves the account