### PR TITLE
Move chime sounds from key press/release to message send/receive

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -105,9 +105,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let invokeKeyDown = InvokeHotKey.stored().isPressed(in: event.modifierFlags)
         if invokeKeyDown && !commandKeyHeld {
             commandKeyHeld = true
-            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
-                soundPlayer.playPress()
-            }
 
             // Reuse an existing visible non-chat panel if one exists
             if let existing = panels.first(where: {
@@ -125,9 +122,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } else if !invokeKeyDown && commandKeyHeld {
             commandKeyHeld = false
-            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
-                soundPlayer.playRelease()
-            }
             if let panel = commandKeyPanel {
                 panel.isCommandKeyHeld = false
                 panel.endCommandKeyMode()
@@ -338,6 +332,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.openFeedbackPage()
         }
         panel.onMessageSent = { [weak self] in
+            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
+                self?.soundPlayer.playPress()
+            }
+        }
+        panel.onStreamingComplete = { [weak self] in
             if UserDefaults.standard.bool(forKey: "chimeEnabled") {
                 self?.soundPlayer.playRelease()
             }

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -166,6 +166,7 @@ class FloatingPanel: NSPanel {
     var onCommandKeyDropped: (() -> Void)?
     var onFeedbackShake: (() -> Void)?
     var onMessageSent: (() -> Void)?
+    var onStreamingComplete: (() -> Void)?
 
     init() {
         super.init(
@@ -194,6 +195,9 @@ class FloatingPanel: NSPanel {
         }
         searchViewModel.onMessageSent = { [weak self] in
             self?.onMessageSent?()
+        }
+        searchViewModel.onStreamingComplete = { [weak self] in
+            self?.onStreamingComplete?()
         }
         searchViewModel.onClose = { [weak self] in
             self?.close()
@@ -373,6 +377,7 @@ class FloatingPanel: NSPanel {
             if let sid = manager.sessionId {
                 self?.searchViewModel.currentSessionId = sid
             }
+            self?.onStreamingComplete?()
         }
         searchViewModel.claudeManager = manager
         searchViewModel.isChatMode = true

--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -626,7 +626,7 @@ private struct FinishStep: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Chime sound")
                     .font(.system(size: 15, weight: .semibold))
-                Text("Play a chime when you press and release the invoke key.")
+                Text("Play a chime when you send a message and when a response arrives.")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -36,6 +36,7 @@ class SearchViewModel: ObservableObject {
     var onSubmit: ((String, URL?) -> Void)?
     var onClose: (() -> Void)?
     var onMessageSent: (() -> Void)?
+    var onStreamingComplete: (() -> Void)?
 
     var isVoiceModeActive: Bool {
         switch voiceState {
@@ -65,6 +66,7 @@ class SearchViewModel: ObservableObject {
                 if let sid = manager.sessionId {
                     self?.currentSessionId = sid
                 }
+                self?.onStreamingComplete?()
             }
             claudeManager = manager
             manager.start(message: message, resumeSessionId: currentSessionId)


### PR DESCRIPTION
## Summary
- Play C5 chime when a message is sent (streaming starts)
- Play A4 chime when a response is received (streaming stops)
- Remove chimes from holding and releasing the invoke key
- Update onboarding description to reflect the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)