### PR TITLE
Fix packaged app launch crash

### DIFF
--- a/Sources/PTTSoundPlayer.swift
+++ b/Sources/PTTSoundPlayer.swift
@@ -2,6 +2,7 @@ import AppKit
 
 /// Preloads PTT chime sounds into memory so playback is instantaneous.
 class PTTSoundPlayer {
+    private static let resourceBundleName = "HyperPointer_HyperPointer"
     private let pressSound: NSSound?
     private let releaseSound: NSSound?
 
@@ -23,9 +24,39 @@ class PTTSoundPlayer {
     }
 
     private static func loadSound(named name: String) -> NSSound? {
-        if let url = Bundle.module.url(forResource: name, withExtension: "wav") {
-            return NSSound(contentsOf: url, byReference: false)
+        for url in resourceCandidateURLs(for: name, ext: "wav") {
+            if let sound = NSSound(contentsOf: url, byReference: false) {
+                return sound
+            }
         }
         return nil
+    }
+
+    private static func resourceCandidateURLs(for name: String, ext: String) -> [URL] {
+        var candidates: [URL] = []
+
+        if let mainResourceURL = Bundle.main.resourceURL {
+            candidates.append(mainResourceURL.appendingPathComponent("\(name).\(ext)"))
+            candidates.append(
+                mainResourceURL
+                    .appendingPathComponent("\(resourceBundleName).bundle")
+                    .appendingPathComponent("\(name).\(ext)")
+            )
+        }
+
+        if let executableURL = Bundle.main.executableURL?.deletingLastPathComponent() {
+            candidates.append(
+                executableURL
+                    .appendingPathComponent("\(resourceBundleName).bundle")
+                    .appendingPathComponent("\(name).\(ext)")
+            )
+        }
+
+        var seen = Set<String>()
+        return candidates.filter { url in
+            let path = url.standardizedFileURL.path
+            guard seen.insert(path).inserted else { return false }
+            return FileManager.default.fileExists(atPath: path)
+        }
     }
 }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -94,6 +94,11 @@ cp "$BINARY_PATH" "$MACOS_PATH/$APP_NAME"
 cp "$ROOT_DIR/Sources/Info.plist" "$CONTENTS_PATH/Info.plist"
 cp "$ROOT_DIR/Sources/Resources"/*.wav "$RESOURCES_PATH/"
 
+RESOURCE_BUNDLE="$(find "$BIN_DIR" -maxdepth 1 -name "${APP_NAME}_*.bundle" -type d 2>/dev/null | head -1)"
+if [[ -n "$RESOURCE_BUNDLE" ]]; then
+  cp -R "$RESOURCE_BUNDLE" "$RESOURCES_PATH/"
+fi
+
 # Embed Sparkle.framework (extracted by SPM into .build/artifacts/)
 SPARKLE_FRAMEWORK="$(find "$ROOT_DIR/.build/artifacts" -name "Sparkle.framework" -type d 2>/dev/null | head -1)"
 if [[ -n "$SPARKLE_FRAMEWORK" ]]; then

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -95,6 +95,12 @@ rm -rf "$APP_PATH"
 mkdir -p "$MACOS_PATH" "$RESOURCES_PATH"
 cp "$BINARY_PATH" "$MACOS_PATH/$APP_NAME"
 cp "$ROOT_DIR/Sources/Info.plist" "$CONTENTS_PATH/Info.plist"
+cp "$ROOT_DIR/Sources/Resources"/*.wav "$RESOURCES_PATH/"
+
+RESOURCE_BUNDLE="$(find "$BIN_DIR" -maxdepth 1 -name "${APP_NAME}_*.bundle" -type d 2>/dev/null | head -1)"
+if [[ -n "$RESOURCE_BUNDLE" ]]; then
+  cp -R "$RESOURCE_BUNDLE" "$RESOURCES_PATH/"
+fi
 
 # Embed Sparkle.framework so the packaged app can launch from the dev bundle.
 SPARKLE_FRAMEWORK="$(find "$ROOT_DIR/.build/artifacts" -name "Sparkle.framework" -type d 2>/dev/null | head -1)"


### PR DESCRIPTION
Packaged HyperPointer builds were crashing on launch because PTTSoundPlayer assumed SwiftPM's Bundle.module resource layout, but the generated resource bundle was not being copied into the shipped app. This updates the sound loader to look in the app bundle and adjacent SwiftPM resource bundle paths without asserting, and updates both packaging scripts to copy the generated HyperPointer_*.bundle into Contents/Resources. I verified the fix by building with ./scripts/build-app.sh --sign-mode skip, confirming the resource bundle is present in dist/HyperPointer.app, and launching the packaged app successfully.
