### PR TITLE
Add settings panel for HyperPointer

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var localFlagsMonitor: Any?
     private var statusItem: NSStatusItem?
     private var onboardingWindow: NSWindow?
+    private var settingsWindow: NSWindow?
     private var commandKeyHeld = false
     private weak var commandKeyPanel: FloatingPanel?
     private var updaterController: SPUStandardUpdaterController?
@@ -67,7 +68,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         sharedAppDelegate = self
-        UserDefaults.standard.register(defaults: ["chimeEnabled": true])
+        AppSettings.registerDefaults()
         setupMainMenu()
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
         setupStatusItem()
@@ -102,7 +103,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleFlagsChanged(_ event: NSEvent) {
-        let invokeKeyDown = InvokeHotKey.stored().isPressed(in: event.modifierFlags)
+        let modifierFlags = event.modifierFlags
+        let invokeKeyDown = InvokeHotKey.stored().isPressed(in: modifierFlags)
         if invokeKeyDown && !commandKeyHeld {
             commandKeyHeld = true
 
@@ -112,18 +114,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }) {
                 commandKeyPanel = existing
                 existing.isCommandKeyHeld = true
-                existing.restartCommandKeyMode()
+                existing.restartCommandKeyMode(with: modifierFlags)
             } else {
                 panels.removeAll { !$0.isVisible }
                 let panel = makePanel()
                 commandKeyPanel = panel
                 panels.append(panel)
-                panel.startCommandKeyMode()
+                panel.startCommandKeyMode(with: modifierFlags)
             }
+        } else if invokeKeyDown && commandKeyHeld {
+            commandKeyPanel?.updateModifierFlags(modifierFlags)
         } else if !invokeKeyDown && commandKeyHeld {
             commandKeyHeld = false
             if let panel = commandKeyPanel {
                 panel.isCommandKeyHeld = false
+                panel.updateModifierFlags(modifierFlags)
                 panel.endCommandKeyMode()
             }
             commandKeyPanel = nil
@@ -169,11 +174,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let newPanelItem = NSMenuItem(title: "New Panel", action: #selector(handleStatusNewPanel), keyEquivalent: "n")
         newPanelItem.target = self
 
+        let settingsItem = NSMenuItem(title: "Settings…", action: #selector(handleStatusOpenSettings), keyEquivalent: ",")
+        settingsItem.target = self
+
         let checkForUpdatesItem = NSMenuItem(title: "Check for Updates…", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
         checkForUpdatesItem.target = updaterController
         self.checkForUpdatesItem = checkForUpdatesItem
 
-        let onboardingItem = NSMenuItem(title: "Open Onboarding", action: #selector(handleStatusOpenOnboarding), keyEquivalent: ",")
+        let onboardingItem = NSMenuItem(title: "Open Onboarding", action: #selector(handleStatusOpenOnboarding), keyEquivalent: "")
         onboardingItem.target = self
 
         let leaveFeedbackItem = NSMenuItem(title: "Leave Feedback", action: #selector(handleStatusLeaveFeedback), keyEquivalent: "")
@@ -189,6 +197,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(versionItem)
         menu.addItem(.separator())
         menu.addItem(newPanelItem)
+        menu.addItem(settingsItem)
         menu.addItem(killAllItem)
         menu.addItem(onboardingItem)
         menu.addItem(.separator())
@@ -203,6 +212,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func handleStatusNewPanel() {
         createNewPanel()
+    }
+
+    @objc private func handleStatusOpenSettings() {
+        showSettings()
     }
 
     @objc private func handleStatusOpenOnboarding() {
@@ -279,6 +292,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func closeOnboarding() {
         onboardingWindow?.orderOut(nil)
         onboardingWindow = nil
+    }
+
+    private func showSettings() {
+        if let settingsWindow {
+            settingsWindow.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 780, height: 620),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "HyperPointer Settings"
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.contentView = NSHostingView(
+            rootView: SettingsView(
+                onAccessibilityStateChange: { [weak self] isGranted in
+                    self?.updateAccessibilityMonitoring(isGranted: isGranted)
+                }
+            )
+        )
+        window.delegate = self
+
+        settingsWindow = window
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     private func updateAccessibilityMonitoring(isGranted: Bool) {
@@ -476,10 +519,13 @@ extension AppDelegate: SPUUpdaterDelegate {
 
 extension AppDelegate: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        guard let window = notification.object as? NSWindow, window == onboardingWindow else {
-            return
+        guard let window = notification.object as? NSWindow else { return }
+
+        if window == onboardingWindow {
+            onboardingWindow = nil
+        } else if window == settingsWindow {
+            settingsWindow = nil
         }
-        onboardingWindow = nil
     }
 }
 

--- a/Sources/AppSettings.swift
+++ b/Sources/AppSettings.swift
@@ -1,0 +1,128 @@
+import Combine
+import Foundation
+
+enum ClaudeModelPreset: String, CaseIterable, Identifiable {
+    case sonnet46 = "sonnet"
+    case opus46 = "opus"
+    case opus461M = "opus[1m]"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .sonnet46:
+            return "Sonnet 4.6"
+        case .opus46:
+            return "Opus 4.6"
+        case .opus461M:
+            return "Opus 4.6 1M"
+        }
+    }
+}
+
+enum AppSettings {
+    private enum Keys {
+        static let chimeEnabled = "chimeEnabled"
+        static let autoVoiceEnabled = "autoVoiceEnabled"
+        static let defaultModel = "defaultClaudeModel"
+        static let thinkingEnabled = "defaultClaudeThinkingEnabled"
+        static let fastModeEnabled = "defaultClaudeFastModeEnabled"
+    }
+
+    static func registerDefaults(in defaults: UserDefaults = .standard) {
+        defaults.register(defaults: [
+            Keys.chimeEnabled: true,
+            Keys.autoVoiceEnabled: true,
+            Keys.defaultModel: ClaudeModelPreset.sonnet46.rawValue,
+            Keys.thinkingEnabled: false,
+            Keys.fastModeEnabled: true,
+        ])
+    }
+
+    static var invokeHotKey: InvokeHotKey {
+        get { InvokeHotKey.stored() }
+        set { newValue.persist() }
+    }
+
+    static var chimeEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.chimeEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.chimeEnabled) }
+    }
+
+    static var autoVoiceEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.autoVoiceEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.autoVoiceEnabled) }
+    }
+
+    static var defaultModel: ClaudeModelPreset {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: Keys.defaultModel),
+                  let model = ClaudeModelPreset(rawValue: rawValue) else {
+                return .sonnet46
+            }
+            return model
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.defaultModel)
+        }
+    }
+
+    static var thinkingEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.thinkingEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.thinkingEnabled) }
+    }
+
+    static var fastModeEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.fastModeEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.fastModeEnabled) }
+    }
+
+    static var claudeThinkingMode: String {
+        thinkingEnabled ? "enabled" : "disabled"
+    }
+
+    static var claudeSettingsJSONString: String {
+        let payload: [String: Any] = [
+            "fastMode": fastModeEnabled,
+            "fastModePerSessionOptIn": false,
+        ]
+
+        guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+              let string = String(data: data, encoding: .utf8) else {
+            return #"{"fastMode":false,"fastModePerSessionOptIn":false}"#
+        }
+
+        return string
+    }
+}
+
+final class AppSettingsStore: ObservableObject {
+    @Published var invokeHotKey: InvokeHotKey {
+        didSet { AppSettings.invokeHotKey = invokeHotKey }
+    }
+    @Published var chimeEnabled: Bool {
+        didSet { AppSettings.chimeEnabled = chimeEnabled }
+    }
+    @Published var autoVoiceEnabled: Bool {
+        didSet { AppSettings.autoVoiceEnabled = autoVoiceEnabled }
+    }
+    @Published var defaultModel: ClaudeModelPreset {
+        didSet { AppSettings.defaultModel = defaultModel }
+    }
+    @Published var thinkingEnabled: Bool {
+        didSet { AppSettings.thinkingEnabled = thinkingEnabled }
+    }
+    @Published var fastModeEnabled: Bool {
+        didSet { AppSettings.fastModeEnabled = fastModeEnabled }
+    }
+
+    init() {
+        AppSettings.registerDefaults()
+        invokeHotKey = AppSettings.invokeHotKey
+        chimeEnabled = AppSettings.chimeEnabled
+        autoVoiceEnabled = AppSettings.autoVoiceEnabled
+        defaultModel = AppSettings.defaultModel
+        thinkingEnabled = AppSettings.thinkingEnabled
+        fastModeEnabled = AppSettings.fastModeEnabled
+    }
+}

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -157,6 +157,7 @@ class FloatingPanel: NSPanel {
     private var isTerminalMode = false
     private var isCommandKeyVisible = false
     private var isCursorFollowing = false
+    private var currentModifierFlags: NSEvent.ModifierFlags = []
     private var lastReportedContentSize: CGSize = .zero
     private var focusRestorationState: FocusRestorationState?
     private var shouldRestoreFocusOnClose = true
@@ -454,8 +455,9 @@ class FloatingPanel: NSPanel {
 
     /// Called when the invoke hotkey is pressed. Shows a minimal icon indicator immediately,
     /// then expands to the full panel on the first cursor move.
-    func startCommandKeyMode() {
+    func startCommandKeyMode(with modifierFlags: NSEvent.ModifierFlags) {
         isCommandKeyHeld = true
+        currentModifierFlags = modifierFlags
         searchViewModel.isCommandKeyMode = true
         searchViewModel.isMinimalMode = true
         searchViewModel.query = ""
@@ -467,7 +469,7 @@ class FloatingPanel: NSPanel {
         searchViewModel.updateHoveredApp()
         positionAtCursor()
         orderFront(nil)
-        startVoiceModeIfNeeded()
+        updateModifierFlags(modifierFlags)
 
         commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
             guard let self else { return }
@@ -523,19 +525,20 @@ class FloatingPanel: NSPanel {
 
     /// Re-enter cursor-following on an already-visible panel.
     /// Hides the input row only if no text has been typed yet.
-    func restartCommandKeyMode() {
+    func restartCommandKeyMode(with modifierFlags: NSEvent.ModifierFlags) {
         if let m = globalMouseMonitor { NSEvent.removeMonitor(m); globalMouseMonitor = nil }
         if let m = localMouseMonitor { NSEvent.removeMonitor(m); localMouseMonitor = nil }
         if let m = commandKeyMouseMonitor { NSEvent.removeMonitor(m); commandKeyMouseMonitor = nil }
 
         isCommandKeyHeld = true
+        currentModifierFlags = modifierFlags
         isCommandKeyVisible = true
         isCursorFollowing = true
         mouseShakeDetector.reset()
         if searchViewModel.query.isEmpty {
             searchViewModel.isCommandKeyMode = true
         }
-        startVoiceModeIfNeeded()
+        updateModifierFlags(modifierFlags)
 
         // Global monitor fires when another app is frontmost; local monitor fires when we are.
         commandKeyMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: .mouseMoved) { [weak self] _ in
@@ -618,6 +621,7 @@ class FloatingPanel: NSPanel {
         isTerminalMode = false
         isCommandKeyVisible = false
         isCursorFollowing = false
+        currentModifierFlags = []
         isCommandKeyHeld = false
 
         if shouldRestoreFocus {
@@ -640,6 +644,11 @@ class FloatingPanel: NSPanel {
         close()
     }
 
+    func updateModifierFlags(_ modifierFlags: NSEvent.ModifierFlags) {
+        currentModifierFlags = modifierFlags
+        syncVoiceModeWithCurrentModifiers()
+    }
+
     private func startVoiceModeIfNeeded() {
         guard isVisible,
               !isTerminalMode,
@@ -649,6 +658,30 @@ class FloatingPanel: NSPanel {
               !searchViewModel.isVoiceModeActive else { return }
 
         voiceController.start()
+    }
+
+    private func syncVoiceModeWithCurrentModifiers() {
+        guard isVisible,
+              !isTerminalMode,
+              !searchViewModel.isChatMode,
+              isCommandKeyHeld,
+              searchViewModel.isCommandKeyMode else { return }
+
+        guard AppSettings.autoVoiceEnabled || currentModifierFlags.contains(.shift) else {
+            cancelVoiceModeIfNeeded()
+            return
+        }
+
+        startVoiceModeIfNeeded()
+    }
+
+    private func cancelVoiceModeIfNeeded() {
+        switch searchViewModel.voiceState {
+        case .listening, .idle:
+            voiceController.cancel()
+        case .transcribing, .failed:
+            break
+        }
     }
 
     private func stopVoiceModeIfNeeded() {

--- a/Sources/SearchView.swift
+++ b/Sources/SearchView.swift
@@ -164,7 +164,7 @@ struct PanelHeaderSection<Accessory: View>: View {
                     Group {
                         switch viewModel.voiceState {
                         case .listening:
-                            Text("Release Command to send")
+                            Text("Release \(InvokeHotKey.stored().displayName) to send")
                                 .font(.system(size: 13))
                                 .foregroundColor(.secondary)
                         case .transcribing:

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1,0 +1,477 @@
+import AppKit
+import SwiftUI
+
+private enum SettingsSection: String, CaseIterable, Identifiable {
+    case general
+    case chat
+    case permissions
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .general:
+            return "General"
+        case .chat:
+            return "Chat"
+        case .permissions:
+            return "Permissions"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .general:
+            return "Invoke key, sound, and voice behavior"
+        case .chat:
+            return "Claude model defaults"
+        case .permissions:
+            return "macOS access and automation"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .general:
+            return "gearshape"
+        case .chat:
+            return "bubble.left.and.bubble.right"
+        case .permissions:
+            return "hand.raised"
+        }
+    }
+}
+
+struct SettingsView: View {
+    @State private var selectedSection: SettingsSection? = .general
+    @StateObject private var onboardingViewModel: OnboardingViewModel
+    @StateObject private var settingsStore: AppSettingsStore
+
+    init(onAccessibilityStateChange: @escaping (Bool) -> Void) {
+        _onboardingViewModel = StateObject(
+            wrappedValue: OnboardingViewModel(
+                onFinish: {},
+                onAccessibilityStateChange: onAccessibilityStateChange
+            )
+        )
+        _settingsStore = StateObject(wrappedValue: AppSettingsStore())
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            List(SettingsSection.allCases, selection: $selectedSection) { section in
+                Label(section.title, systemImage: section.symbolName)
+                    .tag(section)
+            }
+            .navigationSplitViewColumnWidth(min: 190, ideal: 210)
+            .listStyle(.sidebar)
+        } detail: {
+            Group {
+                switch selectedSection ?? .general {
+                case .general:
+                    GeneralSettingsPane(
+                        onboardingViewModel: onboardingViewModel,
+                        settingsStore: settingsStore
+                    )
+                case .chat:
+                    ChatSettingsPane(settingsStore: settingsStore)
+                case .permissions:
+                    PermissionsSettingsPane(viewModel: onboardingViewModel)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(nsColor: .windowBackgroundColor))
+        }
+    }
+}
+
+private struct GeneralSettingsPane: View {
+    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @ObservedObject var settingsStore: AppSettingsStore
+
+    var body: some View {
+        SettingsPageScaffold(
+            title: "General",
+            subtitle: "Choose how HyperPointer wakes up and how much feedback it gives you while you work."
+        ) {
+            VStack(spacing: 14) {
+                invokeHotkeyCard
+                soundEffectsCard
+                autoVoiceCard
+            }
+        }
+    }
+
+    private var invokeHotkeyCard: some View {
+        SettingsCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Invoke hotkey")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("Choose which modifier key you hold to bring up HyperPointer. Fn is the safest default if you want to avoid clashes with app shortcuts.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Picker("Invoke hotkey", selection: $onboardingViewModel.invokeHotKey) {
+                    ForEach(InvokeHotKey.allCases) { hotKey in
+                        Text(hotKey.displayName).tag(hotKey)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 160)
+            }
+        }
+    }
+
+    private var soundEffectsCard: some View {
+        SettingsCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Sound effects")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("Play the same send and response sounds used during onboarding.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Toggle("", isOn: $onboardingViewModel.chimeEnabled)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+                    .onChange(of: onboardingViewModel.chimeEnabled) { _, enabled in
+                        if enabled {
+                            onboardingViewModel.soundPlayer.playPress()
+                        }
+                    }
+            }
+        }
+    }
+
+    private var autoVoiceCard: some View {
+        SettingsCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Auto-voice")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("When on, voice starts as soon as you hold your invoke key. When off, hold Shift while you hold the invoke key to use voice mode.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Toggle("", isOn: $settingsStore.autoVoiceEnabled)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+            }
+        }
+    }
+}
+
+private struct ChatSettingsPane: View {
+    @ObservedObject var settingsStore: AppSettingsStore
+
+    var body: some View {
+        SettingsPageScaffold(
+            title: "Chat",
+            subtitle: "Pick the Claude defaults HyperPointer should use whenever it opens a new conversation."
+        ) {
+            VStack(spacing: 14) {
+                defaultModelCard
+                fastModeCard
+            }
+        }
+    }
+
+    private var defaultModelCard: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Default model")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("This controls the Claude Code model HyperPointer uses by default, plus whether thinking starts enabled or disabled.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                HStack(spacing: 12) {
+                    Picker("Default model", selection: $settingsStore.defaultModel) {
+                        ForEach(ClaudeModelPreset.allCases) { model in
+                            Text(model.displayName).tag(model)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Picker("Thinking", selection: $settingsStore.thinkingEnabled) {
+                        Text("Thinking off").tag(false)
+                        Text("Thinking on").tag(true)
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 150)
+                }
+            }
+        }
+    }
+
+    private var fastModeCard: some View {
+        SettingsCard {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Default to fast mode")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("Controls whether Opus 4.6 sessions start with Claude Code fast mode enabled. This is on by default.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Toggle("", isOn: $settingsStore.fastModeEnabled)
+                    .toggleStyle(.switch)
+                    .labelsHidden()
+            }
+        }
+    }
+}
+
+private struct PermissionsSettingsPane: View {
+    @ObservedObject var viewModel: OnboardingViewModel
+
+    var body: some View {
+        SettingsPageScaffold(
+            title: "Permissions",
+            subtitle: "These macOS permissions let HyperPointer automate apps, capture context, and support voice input on this Mac."
+        ) {
+            SettingsCard(padding: 0) {
+                VStack(alignment: .leading, spacing: 0) {
+                    SettingsPermissionStatusRow(
+                        title: "Accessibility",
+                        description: "Control UI elements and inspect what is under your pointer.",
+                        icon: "hand.raised",
+                        state: permissionState(
+                            isGranted: viewModel.isAccessibilityGranted,
+                            isBusy: viewModel.isAccessibilityRequestInFlight
+                        ) {
+                            if !viewModel.isAccessibilityGranted {
+                                viewModel.requestAccessibility()
+                            }
+                        }
+                    )
+
+                    divider
+
+                    SettingsPermissionStatusRow(
+                        title: "Screen Recording",
+                        description: "Capture the visible window for context and screenshots.",
+                        icon: "display",
+                        state: permissionState(
+                            isGranted: viewModel.isScreenRecordingGranted,
+                            isBusy: viewModel.isScreenRecordingRequestInFlight
+                        ) {
+                            if !viewModel.isScreenRecordingGranted {
+                                viewModel.requestScreenRecording()
+                            }
+                        }
+                    )
+
+                    divider
+
+                    SettingsPermissionStatusRow(
+                        title: "Microphone",
+                        description: "Allow voice input while you hold your invoke key.",
+                        icon: "mic",
+                        state: permissionState(
+                            isGranted: viewModel.isMicrophoneGranted,
+                            isBusy: viewModel.isMicrophoneRequestInFlight
+                        ) {
+                            if !viewModel.isMicrophoneGranted {
+                                viewModel.requestMicrophone()
+                            }
+                        }
+                    )
+
+                    divider
+
+                    SettingsPermissionStatusRow(
+                        title: "Speech Recognition",
+                        description: "Transcribe dictated prompts on this Mac.",
+                        icon: "waveform",
+                        state: permissionState(
+                            isGranted: viewModel.isSpeechRecognitionGranted,
+                            isBusy: viewModel.isSpeechRecognitionRequestInFlight
+                        ) {
+                            if !viewModel.isSpeechRecognitionGranted {
+                                viewModel.requestSpeechRecognition()
+                            }
+                        }
+                    )
+
+                    divider
+
+                    SettingsPermissionStatusRow(
+                        title: "Automation",
+                        description: "Allow HyperPointer to control other apps via AppleScript.",
+                        icon: "bolt.horizontal.circle",
+                        state: .action("Grant") {
+                            viewModel.openAutomationSettings()
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private var divider: some View {
+        Divider()
+            .padding(.leading, 64)
+    }
+
+    private func permissionState(
+        isGranted: Bool,
+        isBusy: Bool,
+        action: @escaping () -> Void
+    ) -> SettingsPermissionStatusRow.State {
+        if isGranted {
+            return .granted("Granted")
+        }
+        if isBusy || viewModel.isPreparingAppBundle {
+            return .inProgress
+        }
+        return .action("Grant", action)
+    }
+}
+
+private struct SettingsPageScaffold<Content: View>: View {
+    let title: String
+    let subtitle: String
+    @ViewBuilder let content: Content
+
+    init(title: String, subtitle: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content()
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 28, weight: .semibold))
+                    Text(subtitle)
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                content
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 24)
+            .frame(maxWidth: 680, alignment: .leading)
+        }
+    }
+}
+
+private struct SettingsCard<Content: View>: View {
+    let padding: CGFloat
+    @ViewBuilder let content: Content
+
+    init(padding: CGFloat = 18, @ViewBuilder content: () -> Content) {
+        self.padding = padding
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .padding(padding)
+            .background(Color.white.opacity(0.96))
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.black.opacity(0.035), lineWidth: 1)
+            )
+            .shadow(color: Color.black.opacity(0.05), radius: 22, y: 8)
+    }
+}
+
+private struct SettingsPermissionStatusRow: View {
+    enum State {
+        case granted(String)
+        case inProgress
+        case action(String, () -> Void)
+    }
+
+    let title: String
+    let description: String
+    let icon: String
+    let state: State
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(Color.secondary.opacity(0.12))
+                    .frame(width: 36, height: 36)
+
+                Image(systemName: icon)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(description)
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            trailingView
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+    }
+
+    @ViewBuilder
+    private var trailingView: some View {
+        switch state {
+        case .granted(let text):
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.green)
+                Text(text)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.green)
+            }
+        case .inProgress:
+            ProgressView()
+                .controlSize(.small)
+        case .action(let label, let action):
+            Button(label, action: action)
+                .buttonStyle(SettingsPermissionGrantButtonStyle())
+        }
+    }
+}
+
+private struct SettingsPermissionGrantButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Color.primary)
+            .padding(.horizontal, 14)
+            .frame(height: 30)
+            .background(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .fill(Color.secondary.opacity(configuration.isPressed ? 0.16 : 0.12))
+            )
+    }
+}

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -90,22 +90,12 @@ class ClaudeProcessManager: ObservableObject {
         self.process = process
 
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        var claudeCmd: String
         let useStreamJsonInput = stdinData != nil
-        let systemPromptFlag = "--system-prompt \"$HP_SYSTEM\""
-        if useStreamJsonInput {
-            if let sid = resumeSessionId {
-                claudeCmd = "\(claudePath) --print --resume \(sid) \(systemPromptFlag) --input-format stream-json --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
-            } else {
-                claudeCmd = "\(claudePath) --print \(systemPromptFlag) --input-format stream-json --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
-            }
-        } else {
-            if let sid = resumeSessionId {
-                claudeCmd = "\(claudePath) --print --resume \(sid) \(systemPromptFlag) -p \"$HP_MESSAGE\" --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
-            } else {
-                claudeCmd = "\(claudePath) --print \(systemPromptFlag) -p \"$HP_MESSAGE\" --output-format stream-json --verbose --dangerously-skip-permissions 2>&1"
-            }
-        }
+        let claudeCmd = makeClaudeCommand(
+            claudePath: claudePath,
+            resumeSessionId: resumeSessionId,
+            useStreamJSONInput: useStreamJsonInput
+        )
         process.arguments = ["-l", "-c", claudeCmd]
 
         // Set up stdin: pipe for image data, null device for text-only
@@ -232,6 +222,48 @@ class ClaudeProcessManager: ObservableObject {
             status = .error("Failed to launch: \(error.localizedDescription)")
             return
         }
+    }
+
+    private func makeClaudeCommand(
+        claudePath: String,
+        resumeSessionId: String?,
+        useStreamJSONInput: Bool
+    ) -> String {
+        var commandParts = [shellQuoted(claudePath), "--print"]
+
+        if let resumeSessionId {
+            commandParts.append("--resume")
+            commandParts.append(shellQuoted(resumeSessionId))
+        }
+
+        commandParts.append("--model")
+        commandParts.append(shellQuoted(AppSettings.defaultModel.rawValue))
+        commandParts.append("--thinking")
+        commandParts.append(AppSettings.claudeThinkingMode)
+        commandParts.append("--settings")
+        commandParts.append(shellQuoted(AppSettings.claudeSettingsJSONString))
+        commandParts.append("--system-prompt")
+        commandParts.append("\"$HP_SYSTEM\"")
+
+        if useStreamJSONInput {
+            commandParts.append("--input-format")
+            commandParts.append("stream-json")
+        } else {
+            commandParts.append("-p")
+            commandParts.append("\"$HP_MESSAGE\"")
+        }
+
+        commandParts.append("--output-format")
+        commandParts.append("stream-json")
+        commandParts.append("--verbose")
+        commandParts.append("--dangerously-skip-permissions")
+        commandParts.append("2>&1")
+
+        return commandParts.joined(separator: " ")
+    }
+
+    private func shellQuoted(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
     }
 
     private func normalizedScreenshotURL(_ screenshotURL: URL?) -> URL? {


### PR DESCRIPTION
## Summary
Add a dedicated settings window with General, Chat, and Permissions sections, exposed from the menu bar. Persist invoke hotkey, sound effects, auto-voice, Claude model, thinking, and fast-mode defaults in app settings. Reuse the onboarding permission flows inside the new panel so grants and system prompts stay consistent. Wire the runtime behavior so Claude launches with the selected defaults and voice mode only auto-starts when the new auto-voice setting allows it.