### PR TITLE
Persist chat history across app sessions

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -86,6 +86,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         setupStatusItem()
         checkForUpdateInBackground()
         setupRightClickTapIfNeeded()
+        loadPersistedChatSessions()
         showOnboardingIfNeeded()
 
         // Global hotkey: selected invoke key + Space toggles the task overlay.
@@ -335,12 +336,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     @objc private func handleStatusKillAll() {
         closeCommandMenu()
         for panel in panels {
+            panel.saveChatSession()
             panel.searchViewModel.claudeManager?.stop()
             panel.destroyPersistentTaskWindow()
         }
         panels.removeAll()
+        // Reload persisted sessions so they remain visible
         taskRecords.removeAll()
         taskRecordLookup.removeAll()
+        loadPersistedChatSessions()
     }
 
     @objc private func handleStatusQuit() {
@@ -678,7 +682,49 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func openTaskRecord(_ record: TaskSessionRecord) {
-        record.panel?.reopenPersistentTaskWindow()
+        if let panel = record.panel {
+            panel.reopenPersistentTaskWindow()
+            return
+        }
+
+        // Reopen a persisted session that has no live panel
+        guard let persistedId = record.persistedSessionId else { return }
+        let sessions = ChatSessionStore.shared.loadAll()
+        guard let session = sessions.first(where: { $0.id == persistedId }) else { return }
+
+        let panel = makePanel()
+        panels.append(panel)
+        panel.persistedSessionId = persistedId
+
+        // Restore working directory
+        let workingDirectoryURL: URL?
+        if let path = session.workingDirectoryPath {
+            workingDirectoryURL = URL(fileURLWithPath: path)
+        } else {
+            workingDirectoryURL = nil
+        }
+
+        // Populate chat history from persisted messages
+        panel.searchViewModel.chatHistory = session.messages.map {
+            (role: $0.role, text: $0.text, events: [] as [StreamEvent])
+        }
+        panel.searchViewModel.currentSessionId = session.sessionId
+        panel.searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
+        panel.searchViewModel.isChatMode = true
+
+        // Transition to terminal mode to show the restored chat
+        panel.transitionToTerminal(
+            message: "",
+            workingDirectoryURL: workingDirectoryURL,
+            centerWindow: true,
+            restoreOnly: true
+        )
+
+        // Re-associate the record with the live panel
+        record.panel = panel
+        let key = ObjectIdentifier(panel)
+        taskRecordLookup[key] = record
+        record.sync(from: panel)
     }
 
     func stopTaskRecord(_ record: TaskSessionRecord) {
@@ -686,6 +732,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func deleteTaskRecord(_ record: TaskSessionRecord) {
+        // Delete persisted session from disk
+        if let persistedId = record.persistedSessionId {
+            ChatSessionStore.shared.delete(id: persistedId)
+        } else if let panel = record.panel, let persistedId = panel.persistedSessionId {
+            ChatSessionStore.shared.delete(id: persistedId)
+        }
+
         guard let panel = record.panel else {
             taskRecords.removeAll { $0.id == record.id }
             return
@@ -711,6 +764,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
 
         let record = TaskSessionRecord(panel: panel)
+        record.persistedSessionId = panel.persistedSessionId
         taskRecordLookup[key] = record
         taskRecords.append(record)
         sortTaskRecords()
@@ -735,8 +789,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
         let key = ObjectIdentifier(panel)
         if let record = taskRecordLookup.removeValue(forKey: key) {
-            taskRecords.removeAll { $0.id == record.id }
+            // Keep the record in the list if it has a persisted session on disk
+            if let persistedId = panel.persistedSessionId {
+                record.panel = nil
+                record.persistedSessionId = persistedId
+                record.isWindowVisible = false
+                record.isRunning = false
+            } else {
+                taskRecords.removeAll { $0.id == record.id }
+            }
         }
+    }
+
+    private func loadPersistedChatSessions() {
+        let existingPersistedIds = Set(taskRecords.compactMap(\.persistedSessionId))
+        let sessions = ChatSessionStore.shared.loadAll()
+        for session in sessions where !existingPersistedIds.contains(session.id) {
+            let record = TaskSessionRecord(persisted: session)
+            taskRecords.append(record)
+        }
+        sortTaskRecords()
     }
 
     private func sortTaskRecords() {

--- a/Sources/ChatSessionStore.swift
+++ b/Sources/ChatSessionStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct PersistedMessage: Codable {
+    let role: String
+    let text: String
+}
+
+struct PersistedChatSession: Codable {
+    let id: String
+    var sessionId: String?
+    var title: String
+    var subtitle: String
+    var messages: [PersistedMessage]
+    var startedAt: Date
+    var completedAt: Date?
+    var lastActivityAt: Date
+    var workingDirectoryPath: String?
+}
+
+final class ChatSessionStore {
+    static let shared = ChatSessionStore()
+
+    private let sessionsDirectory: URL
+    private let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        e.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return e
+    }()
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+
+    private init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        sessionsDirectory = appSupport.appendingPathComponent("HyperPointer/ChatSessions", isDirectory: true)
+        try? FileManager.default.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
+    }
+
+    private func fileURL(for id: String) -> URL {
+        sessionsDirectory.appendingPathComponent("\(id).json")
+    }
+
+    func save(_ session: PersistedChatSession) {
+        do {
+            let data = try encoder.encode(session)
+            try data.write(to: fileURL(for: session.id), options: .atomic)
+        } catch {
+            print("[ChatSessionStore] Failed to save session \(session.id): \(error)")
+        }
+    }
+
+    func loadAll() -> [PersistedChatSession] {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: sessionsDirectory,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+
+        return files.compactMap { url -> PersistedChatSession? in
+            guard url.pathExtension == "json" else { return nil }
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? decoder.decode(PersistedChatSession.self, from: data)
+        }
+    }
+
+    func delete(id: String) {
+        try? FileManager.default.removeItem(at: fileURL(for: id))
+    }
+}

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -168,6 +168,7 @@ class FloatingPanel: NSPanel {
     private(set) var taskCompletedAt: Date?
     private(set) var taskLastActivityAt: Date?
     private(set) var preservesTaskHistory = false
+    var persistedSessionId: String?
     var isCommandKeyHeld = false
     var onCommandKeyDropped: (() -> Void)?
     var onFeedbackShake: (() -> Void)?
@@ -380,7 +381,8 @@ class FloatingPanel: NSPanel {
         message: String,
         screenshotURL: URL? = nil,
         workingDirectoryURL: URL? = nil,
-        centerWindow: Bool = false
+        centerWindow: Bool = false,
+        restoreOnly: Bool = false
     ) {
         isTerminalMode = true
         isCursorFollowing = false
@@ -411,6 +413,15 @@ class FloatingPanel: NSPanel {
         makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         notifyTaskStateChanged()
+
+        if restoreOnly {
+            // Restoring a persisted session — chat history is already populated
+            searchViewModel.query = ""
+            searchViewModel.claudeManager = nil
+            searchViewModel.isChatMode = true
+            searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
+            return
+        }
 
         // Switch to chat mode — the PanelContentView handles the rest
         searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query, events: []))
@@ -505,6 +516,31 @@ class FloatingPanel: NSPanel {
         notifyTaskStateChanged()
     }
 
+    func saveChatSession() {
+        guard preservesTaskHistory, !searchViewModel.chatHistory.isEmpty else { return }
+
+        let id = persistedSessionId ?? UUID().uuidString
+        persistedSessionId = id
+
+        let messages = searchViewModel.chatHistory.map {
+            PersistedMessage(role: $0.role, text: $0.text)
+        }
+
+        let session = PersistedChatSession(
+            id: id,
+            sessionId: searchViewModel.currentSessionId,
+            title: taskDisplayTitle,
+            subtitle: taskDisplaySubtitle,
+            messages: messages,
+            startedAt: taskStartedAt ?? Date(),
+            completedAt: taskCompletedAt,
+            lastActivityAt: taskLastActivityAt ?? Date(),
+            workingDirectoryPath: searchViewModel.currentSessionWorkingDirectoryURL?.path
+        )
+
+        ChatSessionStore.shared.save(session)
+    }
+
     private func markTaskActivity(completed: Bool = false) {
         guard preservesTaskHistory else { return }
 
@@ -533,6 +569,7 @@ class FloatingPanel: NSPanel {
             let now = Date()
             taskCompletedAt = now
             taskLastActivityAt = now
+            saveChatSession()
         }
 
         notifyTaskStateChanged()
@@ -756,6 +793,7 @@ class FloatingPanel: NSPanel {
         focusRestorationState = nil
         isDestroyingTaskWindow = false
 
+        saveChatSession()
         removeAllMonitors()
         voiceController.cancel()
         super.close()

--- a/Sources/TaskSessionRecord.swift
+++ b/Sources/TaskSessionRecord.swift
@@ -3,9 +3,10 @@ import Combine
 import Foundation
 
 final class TaskSessionRecord: ObservableObject, Identifiable {
-    let id = UUID()
+    let id: UUID
 
     weak var panel: FloatingPanel?
+    var persistedSessionId: String?
 
     @Published var title: String
     @Published var subtitle: String
@@ -19,6 +20,7 @@ final class TaskSessionRecord: ObservableObject, Identifiable {
     init(panel: FloatingPanel) {
         let startedAt = panel.taskStartedAt ?? Date()
 
+        self.id = UUID()
         self.panel = panel
         self.title = panel.taskDisplayTitle
         self.subtitle = panel.taskDisplaySubtitle
@@ -28,6 +30,20 @@ final class TaskSessionRecord: ObservableObject, Identifiable {
         self.lastActivityAt = panel.taskLastActivityAt ?? startedAt
         self.isWindowVisible = panel.isVisible
         self.isRunning = panel.isTaskRunning
+    }
+
+    init(persisted session: PersistedChatSession) {
+        self.id = UUID(uuidString: session.id) ?? UUID()
+        self.panel = nil
+        self.persistedSessionId = session.id
+        self.title = session.title
+        self.subtitle = session.subtitle
+        self.icon = nil
+        self.startedAt = session.startedAt
+        self.completedAt = session.completedAt
+        self.lastActivityAt = session.lastActivityAt
+        self.isWindowVisible = false
+        self.isRunning = false
     }
 
     func sync(from panel: FloatingPanel) {


### PR DESCRIPTION
## Summary

Chat sessions now persist to disk and survive app restarts. Session history remains accessible in the command menu even after panels are closed, allowing users to resume conversations with full chat context intact.

## What changed

- **ChatSessionStore**: New singleton that serializes chat sessions as JSON files in Application Support, with save/load/delete operations
- **FloatingPanel**: Saves sessions automatically after streaming completes and before panel destruction, stores Claude session IDs for resuming conversations
- **AppDelegate**: Loads persisted sessions on app launch and handles reopening them by reconstructing panels with full chat history
- **TaskSessionRecord**: Now supports persisted sessions without live panels, enabling long-term visibility in command menu

Sessions store complete conversation history, working directory context, and Claude session IDs for continued interaction.