### PR TITLE
Restore hover detection on invoke hold for non-chat panels

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -135,7 +135,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         if invokeKeyDown && !commandKeyHeld {
             commandKeyHeld = true
 
-            if let selectedPanel = selectedVisiblePanel() {
+            if let selectedPanel = selectedVisiblePanel(),
+               selectedPanel.searchViewModel.isChatMode {
                 commandKeyPanel = selectedPanel
                 selectedPanel.isCommandKeyHeld = true
                 selectedPanel.startAnchoredVoiceMode(with: modifierFlags)


### PR DESCRIPTION
## Summary
Re-applies the isChatMode condition that gates startAnchoredVoiceMode to chat panels only. Non-chat panels now correctly fall through to restartCommandKeyMode, which re-enters cursor-follow mode.

When holding the invoke key on a non-chat panel, you'll now see the app icon, object name, and voice waveform—restoring the hover detection behavior that was accidentally reverted.

🤖 Generated with Claude Code