### PR TITLE
Embed chats in command menu with drill-down nav

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -80,6 +80,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var taskRecordLookup: [ObjectIdentifier: TaskSessionRecord] = [:]
     @Published var commandMenuVoiceState: SearchViewModel.VoiceState = .idle
     @Published var commandMenuVoiceLevel: CGFloat = 0
+    @Published var commandMenuChatRecord: TaskSessionRecord?
     private lazy var ghostCursorStore = GhostCursorStore(playClickSound: { [weak self] in
         self?.soundPlayer.playGhostCursorClick()
     })
@@ -484,7 +485,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         }
     }
 
-    private func showCommandMenu(from source: CommandMenuPresentationSource) {
+    private func showCommandMenu(from source: CommandMenuPresentationSource, navigateToChat: TaskSessionRecord? = nil) {
+        commandMenuChatRecord = navigateToChat
+
         if commandMenuPanel == nil {
             let panel = CommandMenuPanel(
                 contentRect: NSRect(x: 0, y: 0, width: 720, height: 520),
@@ -501,7 +504,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
             panel.isReleasedWhenClosed = false
             panel.onEscape = { [weak self] in
-                self?.closeCommandMenu()
+                self?.handleCommandMenuEscape()
             }
             commandMenuPanel = panel
         }
@@ -729,6 +732,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             self.ghostCursorStore.unregisterTask(panel.taskId)
             self.removePanel(panel)
         }
+        panel.onTransitionToCommandMenu = { [weak self, weak panel] _ in
+            guard let self, let panel else { return }
+            panel.dismiss(restorePreviousFocus: false)
+            let key = ObjectIdentifier(panel)
+            guard let record = self.taskRecordLookup[key] else { return }
+            self.showCommandMenu(from: .invokeHotKey, navigateToChat: record)
+        }
         panel.onGhostCursorIntent = { [weak self, weak panel] intent in
             guard let self, let panel else { return }
             self.ghostCursorStore.registerTask(panel.taskId, anchorPoint: panel.ghostCursorAnchorPoint)
@@ -752,56 +762,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         return panel
     }
 
-    func launchTaskFromCommandMenu(query: String) {
+    @discardableResult
+    func launchTaskFromCommandMenu(query: String) -> TaskSessionRecord? {
         let panel = makePanel()
         panels.append(panel)
-        panel.startTaskFromMenu(query: query)
+        panel.startTaskFromMenuHeadless(query: query)
+        let key = ObjectIdentifier(panel)
+        return taskRecordLookup[key]
     }
 
     func openTaskRecord(_ record: TaskSessionRecord) {
-        if let panel = record.panel {
-            panel.reopenPersistentTaskWindow()
-            return
-        }
-
-        // Reopen a persisted session that has no live panel
-        guard let persistedId = record.persistedSessionId else { return }
-        let sessions = ChatSessionStore.shared.loadAll()
-        guard let session = sessions.first(where: { $0.id == persistedId }) else { return }
-
-        let panel = makePanel()
-        panels.append(panel)
-        panel.persistedSessionId = persistedId
-
-        // Restore working directory
-        let workingDirectoryURL: URL?
-        if let path = session.workingDirectoryPath {
-            workingDirectoryURL = URL(fileURLWithPath: path)
-        } else {
-            workingDirectoryURL = nil
-        }
-
-        // Populate chat history from persisted messages
-        panel.searchViewModel.chatHistory = session.messages.map {
-            (role: $0.role, text: $0.text, events: [] as [StreamEvent])
-        }
-        panel.searchViewModel.currentSessionId = session.sessionId
-        panel.searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
-        panel.searchViewModel.isChatMode = true
-
-        // Transition to terminal mode to show the restored chat
-        panel.transitionToTerminal(
-            message: "",
-            workingDirectoryURL: workingDirectoryURL,
-            centerWindow: true,
-            restoreOnly: true
-        )
-
-        // Re-associate the record with the live panel
-        record.panel = panel
-        let key = ObjectIdentifier(panel)
-        taskRecordLookup[key] = record
-        record.sync(from: panel)
+        ensureTaskHasLivePanel(record)
+        commandMenuChatRecord = record
     }
 
     func stopTaskRecord(_ record: TaskSessionRecord) {
@@ -833,12 +805,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func closeCommandMenu() {
+        commandMenuChatRecord = nil
         commandMenuVoiceController.cancel()
         commandMenuVoiceState = .idle
         commandMenuVoiceLevel = 0
         tearDownCommandMenuEventMonitors()
         statusItem?.button?.highlight(false)
         commandMenuPanel?.orderOut(nil)
+    }
+
+    func handleCommandMenuEscape() {
+        if let chatRecord = commandMenuChatRecord {
+            if let manager = chatRecord.panel?.searchViewModel.claudeManager,
+               manager.status == .waiting || manager.status == .streaming {
+                manager.stop()
+            } else {
+                commandMenuChatRecord = nil
+            }
+        } else {
+            closeCommandMenu()
+        }
+    }
+
+    func ensureTaskHasLivePanel(_ record: TaskSessionRecord) {
+        if record.panel != nil { return }
+
+        guard let persistedId = record.persistedSessionId else { return }
+        let sessions = ChatSessionStore.shared.loadAll()
+        guard let session = sessions.first(where: { $0.id == persistedId }) else { return }
+
+        let panel = makePanel()
+        panels.append(panel)
+        panel.persistedSessionId = persistedId
+
+        let workingDirectoryURL = session.workingDirectoryPath.map { URL(fileURLWithPath: $0) }
+
+        panel.searchViewModel.chatHistory = session.messages.map {
+            (role: $0.role, text: $0.text, events: [] as [StreamEvent])
+        }
+        panel.searchViewModel.currentSessionId = session.sessionId
+        panel.searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
+
+        panel.restoreHeadless(workingDirectoryURL: workingDirectoryURL)
+
+        record.panel = panel
+        let key = ObjectIdentifier(panel)
+        taskRecordLookup[key] = record
+        record.sync(from: panel)
     }
 
     private func registerTaskRecord(for panel: FloatingPanel) {

--- a/Sources/CommandMenu.swift
+++ b/Sources/CommandMenu.swift
@@ -1,4 +1,5 @@
 import AppKit
+import MarkdownUI
 import SwiftUI
 
 final class CommandMenuPanel: NSPanel {
@@ -194,6 +195,33 @@ struct CommandMenuView: View {
     }
 
     var body: some View {
+        Group {
+            if let chatRecord = appDelegate.commandMenuChatRecord,
+               let viewModel = chatRecord.panel?.searchViewModel {
+                CommandMenuChatDetailView(
+                    task: chatRecord,
+                    viewModel: viewModel,
+                    onBack: { appDelegate.commandMenuChatRecord = nil }
+                )
+            } else {
+                taskListContent
+            }
+        }
+        .frame(width: Self.panelWidth)
+        .reportHeight(CommandMenuTaskListContentHeightPreferenceKey.self)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Color.black.opacity(0.08), lineWidth: 1)
+        )
+        .onPreferenceChange(CommandMenuTaskListContentHeightPreferenceKey.self) { height in
+            guard height > 0 else { return }
+            appDelegate.updateCommandMenuSize(CGSize(width: Self.panelWidth, height: height))
+        }
+    }
+
+    private var taskListContent: some View {
         VStack(spacing: 0) {
             inputRow
 
@@ -230,18 +258,6 @@ struct CommandMenuView: View {
             }
 
             bottomBar
-        }
-        .frame(width: Self.panelWidth)
-        .reportHeight(CommandMenuTaskListContentHeightPreferenceKey.self)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Color.black.opacity(0.08), lineWidth: 1)
-        )
-        .onPreferenceChange(CommandMenuTaskListContentHeightPreferenceKey.self) { height in
-            guard height > 0 else { return }
-            appDelegate.updateCommandMenuSize(CGSize(width: Self.panelWidth, height: height))
         }
         .onAppear {
             hoverSelectionEnabled = false
@@ -337,9 +353,10 @@ struct CommandMenuView: View {
         if queryIsEmpty {
             openSelectedTask()
         } else {
-            appDelegate.launchTaskFromCommandMenu(query: trimmedQuery)
-            query = ""
-            appDelegate.closeCommandMenu()
+            if let record = appDelegate.launchTaskFromCommandMenu(query: trimmedQuery) {
+                query = ""
+                appDelegate.commandMenuChatRecord = record
+            }
         }
     }
 
@@ -361,13 +378,7 @@ struct CommandMenuView: View {
                 return true
             }
 
-            if queryIsEmpty {
-                openSelectedTask()
-            } else {
-                appDelegate.launchTaskFromCommandMenu(query: trimmedQuery)
-                query = ""
-                appDelegate.closeCommandMenu()
-            }
+            submitInput()
             return true
         case 51:
             if hasCommand && hasShift {
@@ -425,7 +436,6 @@ struct CommandMenuView: View {
 
     private func open(_ task: TaskSessionRecord) {
         appDelegate.openTaskRecord(task)
-        appDelegate.closeCommandMenu()
     }
 
     private func stopSelectedTask() {
@@ -537,7 +547,7 @@ private struct CommandMenuTaskRow: View {
     }
 }
 
-private struct TaskRuntimeStatusView: View {
+struct TaskRuntimeStatusView: View {
     @ObservedObject var task: TaskSessionRecord
     @State private var pulse = false
 
@@ -585,6 +595,124 @@ private struct TaskRuntimeStatusView: View {
         }
 
         return "\(seconds)s"
+    }
+}
+
+private struct CommandMenuChatDetailView: View {
+    @ObservedObject var task: TaskSessionRecord
+    @ObservedObject var viewModel: SearchViewModel
+    let onBack: () -> Void
+
+    @State private var chatTextWidth: CGFloat = FocusedTextField.minWidth
+    @State private var chatTextHeight: CGFloat = 18
+
+    var body: some View {
+        VStack(spacing: 0) {
+            chatHeader
+
+            Divider()
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    HStack(alignment: .top, spacing: 0) {
+                        chatTranscript
+                        Spacer(minLength: 0)
+                    }
+                }
+                .onAppear {
+                    proxy.scrollTo("chatBottom", anchor: .bottom)
+                }
+                .onChange(of: viewModel.claudeManager?.outputText) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("chatBottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.chatHistory.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("chatBottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.events.count) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("chatBottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.status) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("chatBottom", anchor: .bottom)
+                    }
+                }
+                .onChange(of: viewModel.claudeManager?.activeToolName) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        proxy.scrollTo("chatBottom", anchor: .bottom)
+                    }
+                }
+            }
+
+            Divider()
+
+            PanelInputRow(
+                viewModel: viewModel,
+                textWidth: $chatTextWidth,
+                textHeight: $chatTextHeight,
+                expandsTextField: true
+            )
+        }
+        .frame(height: 520)
+    }
+
+    private var chatHeader: some View {
+        HStack(spacing: 12) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+
+            if let icon = task.icon {
+                Image(nsImage: icon)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 20, height: 20)
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+            }
+
+            Text(task.title)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            Spacer(minLength: 16)
+
+            TaskRuntimeStatusView(task: task)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 12)
+    }
+
+    private var chatTranscript: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(viewModel.chatHistory.enumerated()), id: \.offset) { _, entry in
+                if entry.role == "user" {
+                    Text("> \(entry.text)")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.secondary)
+                } else {
+                    EventsSummaryView(events: entry.events, isDone: true)
+                    AssistantMarkdown(text: entry.text)
+                }
+            }
+
+            if let manager = viewModel.claudeManager {
+                StreamingContentView(manager: manager)
+            }
+
+            Spacer().frame(height: 0).id("chatBottom")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
     }
 }
 

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -185,6 +185,7 @@ class FloatingPanel: NSPanel {
     var onTaskStateChanged: ((FloatingPanel) -> Void)?
     var onPanelDestroyed: ((FloatingPanel) -> Void)?
     var onGhostCursorIntent: ((GhostCursorIntent) -> Void)?
+    var onTransitionToCommandMenu: ((FloatingPanel) -> Void)?
 
     var taskDisplayTitle: String {
         let fallback = searchViewModel.query.isEmpty ? "New task" : searchViewModel.query
@@ -249,11 +250,21 @@ class FloatingPanel: NSPanel {
 
         // Wire up the submit callback
         searchViewModel.onSubmit = { [weak self] context, screenshotURL, workingDirectoryURL in
-            self?.transitionToTerminal(
-                message: context,
-                screenshotURL: screenshotURL,
-                workingDirectoryURL: workingDirectoryURL
-            )
+            guard let self else { return }
+            if self.onTransitionToCommandMenu != nil {
+                self.startHeadless(
+                    message: context,
+                    screenshotURL: screenshotURL,
+                    workingDirectoryURL: workingDirectoryURL
+                )
+                self.onTransitionToCommandMenu?(self)
+            } else {
+                self.transitionToTerminal(
+                    message: context,
+                    screenshotURL: screenshotURL,
+                    workingDirectoryURL: workingDirectoryURL
+                )
+            }
         }
         searchViewModel.onMessageSent = { [weak self] in
             self?.markTaskActivity()
@@ -488,6 +499,66 @@ class FloatingPanel: NSPanel {
             workingDirectoryURL: searchViewModel.hoveredWorkingDirectoryURL,
             centerWindow: true
         )
+    }
+
+    func startHeadless(
+        message: String,
+        screenshotURL: URL? = nil,
+        workingDirectoryURL: URL? = nil
+    ) {
+        isTerminalMode = true
+        isCursorFollowing = false
+        removeAllMonitors()
+        beginPersistentTaskIfNeeded()
+
+        searchViewModel.chatHistory.append((role: "user", text: searchViewModel.query, events: []))
+        searchViewModel.query = ""
+
+        let manager = ClaudeProcessManager()
+        manager.onComplete = { [weak self] response in
+            let completedEvents = manager.events
+            manager.outputText = ""
+            manager.events = []
+            self?.searchViewModel.chatHistory.append((role: "assistant", text: response, events: completedEvents))
+            if let sid = manager.sessionId {
+                self?.searchViewModel.currentSessionId = sid
+            }
+            self?.onStreamingComplete?()
+        }
+        searchViewModel.claudeManager = manager
+        searchViewModel.isChatMode = true
+        searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
+        notifyTaskStateChanged()
+
+        manager.start(
+            message: message,
+            screenshotURL: screenshotURL,
+            workingDirectoryURL: workingDirectoryURL
+        )
+    }
+
+    func startTaskFromMenuHeadless(query: String) {
+        searchViewModel.configureHomeFolderContext()
+        searchViewModel.query = query
+        let message = searchViewModel.buildContextMessage()
+        let (screenshotURL, _) = searchViewModel.captureFullScreenScreenshot()
+        startHeadless(
+            message: message,
+            screenshotURL: screenshotURL,
+            workingDirectoryURL: searchViewModel.hoveredWorkingDirectoryURL
+        )
+    }
+
+    func restoreHeadless(workingDirectoryURL: URL?) {
+        isTerminalMode = true
+        isCursorFollowing = false
+        removeAllMonitors()
+        beginPersistentTaskIfNeeded()
+
+        searchViewModel.query = ""
+        searchViewModel.claudeManager = nil
+        searchViewModel.isChatMode = true
+        searchViewModel.currentSessionWorkingDirectoryURL = workingDirectoryURL
     }
 
     func reopenPersistentTaskWindow() {

--- a/Sources/TaskSessionRecord.swift
+++ b/Sources/TaskSessionRecord.swift
@@ -46,6 +46,10 @@ final class TaskSessionRecord: ObservableObject, Identifiable {
         self.isRunning = false
     }
 
+    var searchViewModel: SearchViewModel? {
+        panel?.searchViewModel
+    }
+
     func sync(from panel: FloatingPanel) {
         self.panel = panel
         title = panel.taskDisplayTitle

--- a/Sources/TerminalContentView.swift
+++ b/Sources/TerminalContentView.swift
@@ -762,7 +762,7 @@ private struct PanelContentSizePreferenceKey: PreferenceKey {
 
 // MARK: - Markdown message renderer
 
-private extension Theme {
+extension Theme {
     static let assistant = Theme()
         .text {
             ForegroundColor(.primary)
@@ -809,7 +809,7 @@ private extension Theme {
         }
 }
 
-private struct AssistantMarkdown: View {
+struct AssistantMarkdown: View {
     let text: String
     var body: some View {
         Markdown(text)


### PR DESCRIPTION
## Summary
- Chats now open inline within the command menu instead of as separate floating windows
- Selecting a task or submitting a query drills into the chat view with a back arrow and input row at bottom
- Escape returns to task list or closes the menu; escape while streaming stops the stream
- Tasks continue running headlessly in background panels while user navigates

## Implementation
- Added headless task execution (`startHeadless`, `restoreHeadless`) to FloatingPanel
- Added `CommandMenuChatDetailView` for embedded chat rendering with transcript and input
- Command menu navigation driven by `@Published var commandMenuChatRecord`
- Floating search panels now transition to command menu instead of to visible windows via `onTransitionToCommandMenu` callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)