### PR TITLE
Fix command menu z-index and improve task navigation UX

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -67,6 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var commandMenuLocalMouseMonitor: Any?
     private var onboardingWindow: NSWindow?
     private var settingsWindow: NSWindow?
+    private var panelsPendingCommandMenuReveal: Set<ObjectIdentifier> = []
     private var commandKeyHeld = false
     private weak var commandKeyPanel: FloatingPanel?
     private let commandMenuVoiceController = VoiceDictationController()
@@ -81,6 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     @Published var commandMenuVoiceState: SearchViewModel.VoiceState = .idle
     @Published var commandMenuVoiceLevel: CGFloat = 0
     @Published var commandMenuChatRecord: TaskSessionRecord?
+    private var rememberedCommandMenuChatRecordID: TaskSessionRecord.ID?
     private lazy var ghostCursorStore = GhostCursorStore(playClickSound: { [weak self] in
         self?.soundPlayer.playGhostCursorClick()
     })
@@ -498,7 +500,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     private func showCommandMenu(from source: CommandMenuPresentationSource, navigateToChat: TaskSessionRecord? = nil) {
-        commandMenuChatRecord = navigateToChat
+        setCommandMenuChatRecord(resolvedCommandMenuChatRecord(preferred: navigateToChat))
 
         if commandMenuPanel == nil {
             let panel = CommandMenuPanel(
@@ -509,7 +511,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             )
             panel.isFloatingPanel = true
             panel.hidesOnDeactivate = false
-            panel.level = .statusBar
+            panel.level = .floating
             panel.isOpaque = false
             panel.backgroundColor = .clear
             panel.hasShadow = true
@@ -711,12 +713,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             self?.openFeedbackPage()
         }
         panel.onMessageSent = { [weak self, weak panel] in
-            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
-                self?.soundPlayer.playPress()
-            }
             guard let self, let panel else { return }
             self.ghostCursorStore.registerTask(panel.taskId, anchorPoint: panel.ghostCursorAnchorPoint)
             self.ghostCursorStore.setTaskVisible(panel.taskId, visible: false)
+        }
+        panel.onStreamingBegan = { [weak self] in
+            if UserDefaults.standard.bool(forKey: "chimeEnabled") {
+                self?.soundPlayer.playPress()
+            }
         }
         panel.onStreamingComplete = { [weak self, weak panel] in
             if UserDefaults.standard.bool(forKey: "chimeEnabled") {
@@ -724,6 +728,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             }
             guard let self, let panel else { return }
             self.ghostCursorStore.setTaskVisible(panel.taskId, visible: false)
+            self.presentCompletedTaskInCommandMenuIfNeeded(for: panel)
         }
         panel.onPersistentTaskStarted = { [weak self, weak panel] _ in
             guard let self, let panel else { return }
@@ -738,6 +743,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             if !panel.isTaskRunning {
                 self.ghostCursorStore.setTaskVisible(panel.taskId, visible: false)
             }
+            self.presentCompletedTaskInCommandMenuIfNeeded(for: panel)
         }
         panel.onPanelDestroyed = { [weak self, weak panel] _ in
             guard let self, let panel else { return }
@@ -747,9 +753,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         panel.onTransitionToCommandMenu = { [weak self, weak panel] _ in
             guard let self, let panel else { return }
             panel.dismiss(restorePreviousFocus: false)
-            let key = ObjectIdentifier(panel)
-            guard let record = self.taskRecordLookup[key] else { return }
-            self.showCommandMenu(from: .invokeHotKey, navigateToChat: record)
+            self.scheduleCommandMenuReveal(for: panel)
         }
         panel.onGhostCursorIntent = { [weak self, weak panel] intent in
             guard let self, let panel else { return }
@@ -777,6 +781,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     @discardableResult
     func launchTaskFromCommandMenu(query: String) -> TaskSessionRecord? {
         let panel = makePanel()
+        scheduleCommandMenuReveal(for: panel)
+        closeCommandMenu()
         panels.append(panel)
         panel.startTaskFromMenuHeadless(query: query)
         let key = ObjectIdentifier(panel)
@@ -785,7 +791,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
 
     func openTaskRecord(_ record: TaskSessionRecord) {
         ensureTaskHasLivePanel(record)
-        commandMenuChatRecord = record
+        setCommandMenuChatRecord(record)
     }
 
     func stopTaskRecord(_ record: TaskSessionRecord) {
@@ -799,6 +805,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func deleteTaskRecord(_ record: TaskSessionRecord) {
+        if rememberedCommandMenuChatRecordID == record.id {
+            clearCommandMenuChatRecord()
+        }
+
         // Delete persisted session from disk
         if let persistedId = record.persistedSessionId {
             ChatSessionStore.shared.delete(id: persistedId)
@@ -817,6 +827,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func closeCommandMenu() {
+        if let commandMenuChatRecord {
+            rememberedCommandMenuChatRecordID = commandMenuChatRecord.id
+        }
         commandMenuChatRecord = nil
         commandMenuVoiceController.cancel()
         commandMenuVoiceState = .idle
@@ -826,13 +839,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         commandMenuPanel?.orderOut(nil)
     }
 
+    func handleCommandMenuBackNavigation() {
+        clearCommandMenuChatRecord()
+    }
+
     func handleCommandMenuEscape() {
         if let chatRecord = commandMenuChatRecord {
             if let manager = chatRecord.panel?.searchViewModel.claudeManager,
                manager.status == .waiting || manager.status == .streaming {
                 manager.stop()
             } else {
-                commandMenuChatRecord = nil
+                clearCommandMenuChatRecord()
             }
         } else {
             closeCommandMenu()
@@ -899,6 +916,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         panels.removeAll { $0 === panel }
 
         let key = ObjectIdentifier(panel)
+        panelsPendingCommandMenuReveal.remove(key)
         if let record = taskRecordLookup.removeValue(forKey: key) {
             // Keep the record in the list if it has a persisted session on disk
             if let persistedId = panel.persistedSessionId {
@@ -929,6 +947,47 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
             }
             return lhs.lastActivityAt > rhs.lastActivityAt
         }
+    }
+
+    private func scheduleCommandMenuReveal(for panel: FloatingPanel) {
+        let key = ObjectIdentifier(panel)
+        panelsPendingCommandMenuReveal.insert(key)
+        presentCompletedTaskInCommandMenuIfNeeded(for: panel)
+    }
+
+    private func presentCompletedTaskInCommandMenuIfNeeded(for panel: FloatingPanel) {
+        let key = ObjectIdentifier(panel)
+        guard panelsPendingCommandMenuReveal.contains(key),
+              panel.taskCompletedAt != nil,
+              let record = taskRecordLookup[key] else { return }
+
+        panelsPendingCommandMenuReveal.remove(key)
+        showCommandMenu(from: .invokeHotKey, navigateToChat: record)
+    }
+
+    private func setCommandMenuChatRecord(_ record: TaskSessionRecord?) {
+        commandMenuChatRecord = record
+        rememberedCommandMenuChatRecordID = record?.id
+    }
+
+    private func clearCommandMenuChatRecord() {
+        commandMenuChatRecord = nil
+        rememberedCommandMenuChatRecordID = nil
+    }
+
+    private func resolvedCommandMenuChatRecord(preferred record: TaskSessionRecord?) -> TaskSessionRecord? {
+        if let record {
+            ensureTaskHasLivePanel(record)
+            return record
+        }
+
+        guard let rememberedID = rememberedCommandMenuChatRecordID,
+              let rememberedRecord = taskRecords.first(where: { $0.id == rememberedID }) else {
+            return nil
+        }
+
+        ensureTaskHasLivePanel(rememberedRecord)
+        return rememberedRecord
     }
 
     private func selectedVisiblePanel() -> FloatingPanel? {
@@ -1020,7 +1079,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
         commandMenuVoiceController.onTranscript = { [weak self] transcript in
             guard let self, self.commandMenuPanel?.isVisible == true else { return }
             self.launchTaskFromCommandMenu(query: transcript)
-            self.closeCommandMenu()
         }
     }
 

--- a/Sources/CommandMenu.swift
+++ b/Sources/CommandMenu.swift
@@ -201,7 +201,7 @@ struct CommandMenuView: View {
                 CommandMenuChatDetailView(
                     task: chatRecord,
                     viewModel: viewModel,
-                    onBack: { appDelegate.commandMenuChatRecord = nil }
+                    onBack: { appDelegate.handleCommandMenuBackNavigation() }
                 )
             } else {
                 taskListContent
@@ -346,9 +346,8 @@ struct CommandMenuView: View {
         if queryIsEmpty {
             openSelectedTask()
         } else {
-            if let record = appDelegate.launchTaskFromCommandMenu(query: trimmedQuery) {
+            if appDelegate.launchTaskFromCommandMenu(query: trimmedQuery) != nil {
                 query = ""
-                appDelegate.commandMenuChatRecord = record
             }
         }
     }

--- a/Sources/FloatingPanel.swift
+++ b/Sources/FloatingPanel.swift
@@ -180,6 +180,7 @@ class FloatingPanel: NSPanel {
     var onCommandKeyDropped: (() -> Void)?
     var onFeedbackShake: (() -> Void)?
     var onMessageSent: (() -> Void)?
+    var onStreamingBegan: (() -> Void)?
     var onStreamingComplete: (() -> Void)?
     var onPersistentTaskStarted: ((FloatingPanel) -> Void)?
     var onTaskStateChanged: ((FloatingPanel) -> Void)?
@@ -249,9 +250,11 @@ class FloatingPanel: NSPanel {
         contentView = hostingView
 
         // Wire up the submit callback
-        searchViewModel.onSubmit = { [weak self] context, screenshotURL, workingDirectoryURL in
+        searchViewModel.onSubmit = { [weak self] context, workingDirectoryURL in
             guard let self else { return }
             if self.onTransitionToCommandMenu != nil {
+                orderOut(nil)
+                let (screenshotURL, _) = searchViewModel.captureHoveredWindowScreenshot()
                 self.startHeadless(
                     message: context,
                     screenshotURL: screenshotURL,
@@ -259,6 +262,7 @@ class FloatingPanel: NSPanel {
                 )
                 self.onTransitionToCommandMenu?(self)
             } else {
+                let (screenshotURL, _) = searchViewModel.captureHoveredWindowScreenshot()
                 self.transitionToTerminal(
                     message: context,
                     screenshotURL: screenshotURL,
@@ -665,9 +669,13 @@ class FloatingPanel: NSPanel {
         guard preservesTaskHistory else { return }
 
         switch status {
-        case .waiting, .streaming:
+        case .waiting:
             taskCompletedAt = nil
             taskLastActivityAt = Date()
+        case .streaming:
+            taskCompletedAt = nil
+            taskLastActivityAt = Date()
+            onStreamingBegan?()
         case .done, .error:
             let now = Date()
             taskCompletedAt = now

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -43,7 +43,7 @@ class SearchViewModel: ObservableObject {
     private let staleThreshold = 3
 
     /// Set by FloatingPanel
-    var onSubmit: ((String, URL?, URL?) -> Void)?
+    var onSubmit: ((String, URL?) -> Void)?
     var onClose: (() -> Void)?
     var onMessageSent: (() -> Void)?
     var onStreamingComplete: (() -> Void)?
@@ -87,8 +87,7 @@ class SearchViewModel: ObservableObject {
         } else {
             // First message — switch to chat mode
             let context = buildContextMessage()
-            let (screenshotURL, _) = captureHoveredWindowScreenshot()
-            onSubmit?(context, screenshotURL, hoveredWorkingDirectoryURL)
+            onSubmit?(context, hoveredWorkingDirectoryURL)
         }
     }
 


### PR DESCRIPTION
## Summary
Fix command menu panel z-index layering and enhance task navigation workflow.

## Changes
- **Z-index fix**: Change command menu panel level from `.statusBar` to `.floating` to prevent it appearing above other critical UI
- **Remember last chat**: Command menu now returns to the previously viewed chat when reopened
- **Deferred reveal**: Close the command menu immediately when launching a task, then re-open it once the task completes
- **Chime timing**: Move press chime from message-sent to streaming-began event for better user feedback
- **Screenshot capture**: Move screenshot capture from SearchViewModel to FloatingPanel transition handler, improving timing and separation of concerns

## Testing
The changes improve the UX flow when launching tasks from the command menu and ensure proper z-index layering of the command menu panel.