### PR TITLE
fix: always show onboarding for new app bundle installs

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -438,23 +438,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     private func hasSeenOnboardingForCurrentInstall() -> Bool {
-        let defaults = UserDefaults.standard
-        let installIdentifier = currentOnboardingInstallIdentifier()
-
-        if defaults.string(forKey: onboardingSeenInstallKey) == installIdentifier {
-            return true
-        }
-
-        guard defaults.bool(forKey: onboardingSeenKey) else {
-            return false
-        }
-
-        guard OnboardingViewModel.coreRequirementsReadyForCurrentSystem else {
-            return false
-        }
-
-        defaults.set(installIdentifier, forKey: onboardingSeenInstallKey)
-        return true
+        // Do not infer completion for a new app bundle from legacy global defaults.
+        // A fresh DMG install on a machine that already granted permissions still
+        // needs to show onboarding the first time that installed bundle launches.
+        UserDefaults.standard.string(forKey: onboardingSeenInstallKey) == currentOnboardingInstallIdentifier()
     }
 
     private func currentOnboardingInstallIdentifier() -> String {


### PR DESCRIPTION
## Summary

- Fixes a bug where a fresh DMG install on a machine that had already granted permissions would skip onboarding entirely.
- The old logic migrated the legacy global `onboardingSeen` default into the install-scoped key, causing new installs to appear as already onboarded.
- Now `hasSeenOnboardingForCurrentInstall` only returns `true` if the install-scoped key was explicitly set for the current bundle — no inference from legacy state.

## Test plan

- [ ] Install on a machine that previously ran the app and granted all permissions — confirm onboarding is shown on first launch of the new bundle.
- [ ] Re-launch the same install — confirm onboarding is NOT shown again.
- [ ] Fresh install on a machine with no prior run — confirm onboarding is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)