### PR TITLE
fix: enforce Developer ID signing and notarization in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,56 +56,85 @@ jobs:
         run: swift package resolve
 
       # -----------------------------------------------------------------------
-      # Code signing — import a self-signed cert so TCC permissions survive
-      # Sparkle updates. Without a stable signature, each new binary gets a
-      # new ad-hoc hash and macOS re-prompts for every permission on first launch.
-      #
-      # One-time setup (run scripts/create-signing-cert.sh, then store outputs):
-      #   SIGNING_CERT_P12          — base64-encoded .p12 file
-      #   SIGNING_CERT_PASSWORD     — password used when exporting the .p12
-      #   SIGNING_CERT_NAME         — Common Name of the cert (e.g. "HyperPointer")
+      # Distribution signing — release artifacts must use a real Developer ID
+      # Application certificate or Gatekeeper will show the malware warning.
       # -----------------------------------------------------------------------
-      - name: Import signing certificate
+      - name: Import Developer ID Application certificate
         id: signing
         env:
-          SIGNING_CERT_P12:      ${{ secrets.SIGNING_CERT_P12 }}
-          SIGNING_CERT_PASSWORD: ${{ secrets.SIGNING_CERT_PASSWORD }}
-          SIGNING_CERT_NAME:     ${{ secrets.SIGNING_CERT_NAME }}
+          DEVELOPER_ID_APPLICATION_P12:      ${{ secrets.DEVELOPER_ID_APPLICATION_P12 }}
+          DEVELOPER_ID_APPLICATION_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_PASSWORD }}
+          DEVELOPER_ID_APPLICATION_NAME:     ${{ secrets.DEVELOPER_ID_APPLICATION_NAME }}
         run: |
-          if [[ -z "${SIGNING_CERT_P12:-}" ]]; then
-            echo "SIGNING_CERT_P12 not set — falling back to ad-hoc signing."
-            echo "sign_mode=ad-hoc"    >> "$GITHUB_OUTPUT"
-            echo "sign_identity="      >> "$GITHUB_OUTPUT"
-          else
-            KEYCHAIN=build.keychain
-            security create-keychain -p "" "$KEYCHAIN"
-            security default-keychain -s "$KEYCHAIN"
-            security unlock-keychain -p "" "$KEYCHAIN"
-            security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+          missing=()
+          for key in \
+            DEVELOPER_ID_APPLICATION_P12 \
+            DEVELOPER_ID_APPLICATION_PASSWORD \
+            DEVELOPER_ID_APPLICATION_NAME
+          do
+            if [[ -z "${!key:-}" ]]; then
+              missing+=("$key")
+            fi
+          done
 
-            echo "$SIGNING_CERT_P12" | base64 --decode > /tmp/signing.p12
-            security import /tmp/signing.p12 -k "$KEYCHAIN" \
-              -P "$SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
-            rm /tmp/signing.p12
-
-            security set-key-partition-list \
-              -S "apple-tool:,apple:,codesign:" -s -k "" "$KEYCHAIN"
-
-            echo "sign_mode=identity"             >> "$GITHUB_OUTPUT"
-            echo "sign_identity=$SIGNING_CERT_NAME" >> "$GITHUB_OUTPUT"
-            echo "Imported certificate: $SIGNING_CERT_NAME"
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required release secrets: ${missing[*]}" >&2
+            exit 1
           fi
+
+          KEYCHAIN=build.keychain-db
+          security create-keychain -p "" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "" "$KEYCHAIN"
+          security set-keychain-settings -t 3600 -u "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN"
+
+          echo "$DEVELOPER_ID_APPLICATION_P12" | base64 --decode > /tmp/developer-id.p12
+          security import /tmp/developer-id.p12 -k "$KEYCHAIN" \
+            -P "$DEVELOPER_ID_APPLICATION_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/xcrun
+          rm /tmp/developer-id.p12
+
+          security set-key-partition-list \
+            -S "apple-tool:,apple:,codesign:" -s -k "" "$KEYCHAIN"
+
+          echo "sign_identity=$DEVELOPER_ID_APPLICATION_NAME" >> "$GITHUB_OUTPUT"
+          echo "Imported certificate: $DEVELOPER_ID_APPLICATION_NAME"
+
+      - name: Build app bundle
+        env:
+          SIGN_IDENTITY: ${{ steps.signing.outputs.sign_identity }}
+        run: |
+          ./scripts/build-app.sh \
+            --sign-mode developer-id \
+            --sign-identity "$SIGN_IDENTITY"
+
+      - name: Notarize app bundle
+        env:
+          APPLE_ID:                    ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:               ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          ./scripts/notarize.sh --path dist/HyperPointer.app
 
       - name: Build DMG
         env:
-          SIGN_MODE:     ${{ steps.signing.outputs.sign_mode }}
           SIGN_IDENTITY: ${{ steps.signing.outputs.sign_identity }}
         run: |
-          ARGS=(--sign-mode "$SIGN_MODE")
-          if [[ -n "$SIGN_IDENTITY" ]]; then
-            ARGS+=(--sign-identity "$SIGN_IDENTITY")
-          fi
-          ./scripts/build-dmg.sh "${ARGS[@]}"
+          ./scripts/build-dmg.sh \
+            --skip-build \
+            --app-path dist/HyperPointer.app \
+            --sign-mode developer-id \
+            --sign-identity "$SIGN_IDENTITY"
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID:                    ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID:               ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          ./scripts/notarize.sh --path dist/HyperPointer.dmg
 
       - name: Collect DMG metadata
         id: dmg

--- a/MACOS_GATEKEEPER_NOTARIZATION_CHECKLIST.md
+++ b/MACOS_GATEKEEPER_NOTARIZATION_CHECKLIST.md
@@ -23,9 +23,9 @@ Ad-hoc signing and self-signed certificates are fine for local testing, but they
 
 ## Current Status
 
-- Repo packaging and release workflow have been updated for Developer ID signing and notarization.
-- Apple Developer account approval is still pending.
-- Actual certificate creation and notarization are blocked until Apple finishes account activation.
+- Local build scripts now support a separate `developer-id` signing mode for distributable artifacts.
+- The release workflow now requires Developer ID certificate secrets and notarizes both the `.app` and `.dmg`.
+- A release from `main` should now fail loudly if those secrets are missing instead of silently publishing an ad-hoc build.
 
 ## Files Already Added Or Updated
 
@@ -46,26 +46,14 @@ Ad-hoc signing and self-signed certificates are fine for local testing, but they
 - `APPLE_APP_SPECIFIC_PASSWORD`
 - `SPARKLE_PRIVATE_KEY`
 
-## What To Do While Waiting For Apple Approval
-
-1. Confirm the Apple ID you will use for notarization has 2FA enabled.
-2. Decide whether CI will use:
-   - Apple ID + app-specific password
-   - App Store Connect API key + `notarytool` keychain profile
-3. Create the GitHub secret placeholders listed above.
-4. Generate or verify the Sparkle signing keypair.
-5. Keep testing local `.app` and `.dmg` builds.
-
-## Release Flow Once Apple Approves The Account
+## What To Do Next
 
 1. Create or download the `Developer ID Application` certificate.
 2. Export it as a `.p12`.
 3. Add the Apple and certificate secrets to GitHub.
-4. Build the app with Developer ID signing.
-5. Notarize and staple the `.app`.
-6. Build the DMG from the stapled app.
-7. Notarize and staple the `.dmg`.
-8. Publish the release.
+4. Confirm the Apple ID used for notarization has 2FA enabled and an app-specific password.
+5. Generate or verify the Sparkle signing keypair.
+6. Run one notarized release from `main` and verify the downloaded DMG opens with the normal internet-download prompt instead of the malware block.
 
 ## Local Commands
 
@@ -109,4 +97,4 @@ Developer ID + notarization flow:
 
 ## One-Line Summary
 
-There is no public shortcut around Apple's process: to move from the malware block to the normal first-open prompt, HyperPointer must ship as a Developer ID signed, notarized, stapled macOS release.
+There is no public shortcut around Apple's process: to move from the malware block to the normal first-open prompt, HyperPointer must ship as a Developer ID signed, notarized, stapled macOS release, and the release pipeline now enforces that path.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ make dmg
 open dist/HyperPointer.dmg
 ```
 
+For local permission persistence across updates, a self-signed identity is enough. For distribution to other Macs, it is not. Gatekeeper's malware warning only goes away when the shipped artifacts are signed with a real `Developer ID Application` certificate, notarized, and stapled.
+
 On first launch, HyperPointer opens an onboarding wizard that walks through:
 
 - Installing or verifying Claude CLI
@@ -130,12 +132,43 @@ This writes the grants directly to the TCC database so no popups ever appear.
 The `.app` and `.dmg` targets now auto-prefer the best available signing identity in your keychain, starting with `Developer ID Application`, then local development identities. If no stable identity is available they fall back to ad-hoc signing. For a distributable artifact on other Macs, use your real Developer ID identity and notarize the result:
 
 ```bash
-SIGN_MODE=identity SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" make dmg
+./scripts/build-app.sh \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.app \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
+
+./scripts/build-dmg.sh \
+  --skip-build \
+  --app-path dist/HyperPointer.app \
+  --sign-mode developer-id \
+  --sign-identity "Developer ID Application: Your Name (TEAMID)"
+
+./scripts/notarize.sh \
+  --path dist/HyperPointer.dmg \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "app-specific-password"
 ```
+
+If you prefer `notarytool` keychain profiles, `scripts/notarize.sh` also accepts `--keychain-profile <profile>`.
 
 ## Sparkle Release Signing
 
 The GitHub Actions release job signs the published DMG with Sparkle's Ed25519 key. It expects a `SPARKLE_PRIVATE_KEY` repository secret containing the exported private key contents, not the `sparkle:edSignature` output.
+
+The release workflow also requires these secrets for Gatekeeper-safe distribution:
+
+- `DEVELOPER_ID_APPLICATION_P12`
+- `DEVELOPER_ID_APPLICATION_PASSWORD`
+- `DEVELOPER_ID_APPLICATION_NAME`
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
 
 To create or recover the matching keypair:
 

--- a/config/macos/distribution.entitlements
+++ b/config/macos/distribution.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="HyperPointer"
+SCRIPT_NAME="$(basename "$0")"
 CONFIGURATION="${BUILD_CONFIGURATION:-release}"
 DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 APP_PATH="$DIST_DIR/$APP_NAME.app"
+ENTITLEMENTS_PATH="$ROOT_DIR/config/macos/distribution.entitlements"
 INSTALL_AFTER_BUILD=0
 RUN_AFTER_BUILD=0
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
@@ -14,7 +16,7 @@ SIGNING_HELPER="$ROOT_DIR/scripts/detect-signing-identity.sh"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [options]
+Usage: $SCRIPT_NAME [options]
 
 Options:
   --configuration <debug|release>  Build configuration (default: release)
@@ -22,7 +24,7 @@ Options:
   --install                        Copy the built app into /Applications
   --run                            Open the built app after packaging
   --sign-identity <identity>       macOS signing identity to use
-  --sign-mode <auto|ad-hoc|identity|skip>
+  --sign-mode <auto|ad-hoc|identity|developer-id|skip>
                                    Signing mode (default: auto)
 EOF
 }
@@ -67,13 +69,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$SIGN_MODE" in
-  auto|ad-hoc|identity|skip)
+  auto|ad-hoc|identity|developer-id|skip)
     ;;
   *)
     echo "Unsupported sign mode: $SIGN_MODE" >&2
     exit 1
     ;;
 esac
+
+is_developer_id_identity() {
+  [[ "$1" == Developer\ ID\ Application:* ]]
+}
 
 resolve_signing_configuration() {
   local detected_identity=""
@@ -85,10 +91,18 @@ resolve_signing_configuration() {
   case "$SIGN_MODE" in
     auto)
       if [[ -n "$SIGN_IDENTITY" ]]; then
-        SIGN_MODE="identity"
+        if is_developer_id_identity "$SIGN_IDENTITY"; then
+          SIGN_MODE="developer-id"
+        else
+          SIGN_MODE="identity"
+        fi
       elif [[ -n "$detected_identity" ]]; then
-        SIGN_MODE="identity"
         SIGN_IDENTITY="$detected_identity"
+        if is_developer_id_identity "$SIGN_IDENTITY"; then
+          SIGN_MODE="developer-id"
+        else
+          SIGN_MODE="identity"
+        fi
       else
         SIGN_MODE="ad-hoc"
       fi
@@ -102,6 +116,23 @@ resolve_signing_configuration() {
         exit 1
       fi
       ;;
+    developer-id)
+      if [[ -z "$SIGN_IDENTITY" && -n "$detected_identity" ]]; then
+        SIGN_IDENTITY="$detected_identity"
+      fi
+      if [[ -z "$SIGN_IDENTITY" ]]; then
+        echo "--sign-mode developer-id requires --sign-identity or a detectable signing identity." >&2
+        exit 1
+      fi
+      if ! is_developer_id_identity "$SIGN_IDENTITY"; then
+        echo "--sign-mode developer-id requires a 'Developer ID Application:' certificate." >&2
+        exit 1
+      fi
+      if [[ ! -f "$ENTITLEMENTS_PATH" ]]; then
+        echo "Missing entitlements file: $ENTITLEMENTS_PATH" >&2
+        exit 1
+      fi
+      ;;
   esac
 }
 
@@ -109,6 +140,8 @@ resolve_signing_configuration
 
 if [[ "$SIGN_MODE" == "identity" ]]; then
   echo "Using signing identity: $SIGN_IDENTITY"
+elif [[ "$SIGN_MODE" == "developer-id" ]]; then
+  echo "Using Developer ID signing identity: $SIGN_IDENTITY"
 else
   echo "Using signing mode: $SIGN_MODE"
 fi
@@ -147,25 +180,58 @@ if [[ "$SIGN_MODE" != "skip" ]]; then
 
   if [[ "$SIGN_MODE" == "identity" ]]; then
     SIGN_ARG="$SIGN_IDENTITY"
+  elif [[ "$SIGN_MODE" == "developer-id" ]]; then
+    SIGN_ARG="$SIGN_IDENTITY"
   else
     SIGN_ARG="-"
   fi
 
-  # Sign nested components before the app bundle
-  if [[ -d "$CONTENTS_PATH/Frameworks/Sparkle.framework" ]]; then
-    # Sign XPC services inside Sparkle
-    find "$CONTENTS_PATH/Frameworks/Sparkle.framework" -name "*.xpc" -type d | while read xpc; do
-      codesign --force --sign "$SIGN_ARG" --timestamp=none "$xpc"
-    done
-    codesign --force --sign "$SIGN_ARG" --timestamp=none "$CONTENTS_PATH/Frameworks/Sparkle.framework"
+  codesign_args=(--force --sign "$SIGN_ARG")
+  if [[ "$SIGN_MODE" == "developer-id" ]]; then
+    codesign_args+=(--options runtime --timestamp)
+  else
+    codesign_args+=(--timestamp=none)
   fi
 
-  codesign \
-    --force \
-    --deep \
-    --sign "$SIGN_ARG" \
-    --timestamp=none \
-    "$APP_PATH"
+  sign_component() {
+    local target_path="$1"
+    local preserve_entitlements="${2:-0}"
+    local sign_args=("${codesign_args[@]}")
+
+    if [[ "$preserve_entitlements" -eq 1 ]]; then
+      sign_args+=(--preserve-metadata=entitlements)
+    fi
+
+    codesign "${sign_args[@]}" "$target_path"
+  }
+
+  # Sign nested components before the app bundle. Sparkle's XPC services need
+  # explicit signing and should not rely on `codesign --deep`.
+  if [[ -d "$CONTENTS_PATH/Frameworks/Sparkle.framework" ]]; then
+    find "$CONTENTS_PATH/Frameworks/Sparkle.framework" -path '*/XPCServices/*.xpc' -type d | sort | while IFS= read -r xpc; do
+      if [[ "$xpc" == *"/Downloader.xpc" ]]; then
+        sign_component "$xpc" 1
+      else
+        sign_component "$xpc"
+      fi
+    done
+
+    if [[ -f "$CONTENTS_PATH/Frameworks/Sparkle.framework/Versions/B/Autoupdate" ]]; then
+      sign_component "$CONTENTS_PATH/Frameworks/Sparkle.framework/Versions/B/Autoupdate"
+    fi
+
+    if [[ -d "$CONTENTS_PATH/Frameworks/Sparkle.framework/Versions/B/Updater.app" ]]; then
+      sign_component "$CONTENTS_PATH/Frameworks/Sparkle.framework/Versions/B/Updater.app"
+    fi
+
+    sign_component "$CONTENTS_PATH/Frameworks/Sparkle.framework"
+  fi
+
+  app_codesign_args=("${codesign_args[@]}")
+  if [[ "$SIGN_MODE" == "developer-id" ]]; then
+    app_codesign_args+=(--entitlements "$ENTITLEMENTS_PATH")
+  fi
+  codesign "${app_codesign_args[@]}" "$APP_PATH"
 fi
 
 echo "Built app bundle: $APP_PATH"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_NAME="HyperPointer"
+SCRIPT_NAME="$(basename "$0")"
 CONFIGURATION="${BUILD_CONFIGURATION:-release}"
 DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 APP_PATH="$DIST_DIR/$APP_NAME.app"
@@ -10,6 +11,8 @@ DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
 VOLUME_NAME="${DMG_VOLUME_NAME:-$APP_NAME}"
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 SIGN_MODE="${SIGN_MODE:-auto}"
+SKIP_BUILD=0
+SIGNING_HELPER="$ROOT_DIR/scripts/detect-signing-identity.sh"
 TEMP_DIR="$(mktemp -d)"
 STAGING_DIR="$TEMP_DIR/staging"
 RW_DMG_PATH="$TEMP_DIR/$APP_NAME-rw.dmg"
@@ -19,16 +22,54 @@ cleanup() {
 }
 trap cleanup EXIT
 
+is_developer_id_identity() {
+  [[ "$1" == Developer\ ID\ Application:* ]]
+}
+
+resolve_dmg_signing_configuration() {
+  local detected_identity=""
+
+  if [[ -z "$SIGN_IDENTITY" && -x "$SIGNING_HELPER" ]]; then
+    detected_identity="$("$SIGNING_HELPER" 2>/dev/null || true)"
+  fi
+
+  case "$SIGN_MODE" in
+    auto)
+      if [[ -n "$SIGN_IDENTITY" ]] && is_developer_id_identity "$SIGN_IDENTITY"; then
+        SIGN_MODE="developer-id"
+      elif [[ -n "$detected_identity" ]] && is_developer_id_identity "$detected_identity"; then
+        SIGN_MODE="developer-id"
+        SIGN_IDENTITY="$detected_identity"
+      fi
+      ;;
+    developer-id)
+      if [[ -z "$SIGN_IDENTITY" && -n "$detected_identity" ]]; then
+        SIGN_IDENTITY="$detected_identity"
+      fi
+      if [[ -z "$SIGN_IDENTITY" ]]; then
+        echo "--sign-mode developer-id requires --sign-identity or a detectable signing identity." >&2
+        exit 1
+      fi
+      if ! is_developer_id_identity "$SIGN_IDENTITY"; then
+        echo "--sign-mode developer-id requires a 'Developer ID Application:' certificate." >&2
+        exit 1
+      fi
+      ;;
+  esac
+}
+
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [options]
+Usage: $SCRIPT_NAME [options]
 
 Options:
   --configuration <debug|release>  Build configuration (default: release)
   --output-dir <path>              Artifact directory (default: ./dist)
+  --app-path <path>                Existing .app bundle to package
+  --skip-build                     Reuse the existing app bundle at --app-path
   --volume-name <name>             Mounted DMG volume name (default: HyperPointer)
   --sign-identity <identity>       macOS signing identity to use for the app build
-  --sign-mode <auto|ad-hoc|identity|skip>
+  --sign-mode <auto|ad-hoc|identity|developer-id|skip>
                                    Signing mode passed through to build-app.sh
 EOF
 }
@@ -44,6 +85,14 @@ while [[ $# -gt 0 ]]; do
       APP_PATH="$DIST_DIR/$APP_NAME.app"
       DMG_PATH="$DIST_DIR/$APP_NAME.dmg"
       shift 2
+      ;;
+    --app-path)
+      APP_PATH="${2:?missing value for --app-path}"
+      shift 2
+      ;;
+    --skip-build)
+      SKIP_BUILD=1
+      shift
       ;;
     --volume-name)
       VOLUME_NAME="${2:?missing value for --volume-name}"
@@ -69,19 +118,28 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+resolve_dmg_signing_configuration
+
 mkdir -p "$DIST_DIR" "$STAGING_DIR"
 
-build_app_args=(
-  --configuration "$CONFIGURATION"
-  --output-dir "$DIST_DIR"
-  --sign-mode "$SIGN_MODE"
-)
+if [[ "$SKIP_BUILD" -eq 1 ]]; then
+  if [[ ! -d "$APP_PATH" ]]; then
+    echo "--skip-build requires an existing app bundle at $APP_PATH" >&2
+    exit 1
+  fi
+else
+  build_app_args=(
+    --configuration "$CONFIGURATION"
+    --output-dir "$DIST_DIR"
+    --sign-mode "$SIGN_MODE"
+  )
 
-if [[ -n "$SIGN_IDENTITY" ]]; then
-  build_app_args+=(--sign-identity "$SIGN_IDENTITY")
+  if [[ -n "$SIGN_IDENTITY" ]]; then
+    build_app_args+=(--sign-identity "$SIGN_IDENTITY")
+  fi
+
+  "$ROOT_DIR/scripts/build-app.sh" "${build_app_args[@]}"
 fi
-
-"$ROOT_DIR/scripts/build-app.sh" "${build_app_args[@]}"
 
 ditto "$APP_PATH" "$STAGING_DIR/$APP_NAME.app"
 ln -s /Applications "$STAGING_DIR/Applications"
@@ -101,5 +159,15 @@ hdiutil convert \
   -format UDZO \
   -imagekey zlib-level=9 \
   -o "$DMG_PATH"
+
+if [[ "$SIGN_MODE" == "developer-id" ]]; then
+  if [[ -z "$SIGN_IDENTITY" ]]; then
+    echo "--sign-mode developer-id requires --sign-identity when packaging a DMG." >&2
+    exit 1
+  fi
+
+  xattr -cr "$DMG_PATH" 2>/dev/null || true
+  codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG_PATH"
+fi
 
 echo "Built installer image: $DMG_PATH"

--- a/scripts/create-signing-cert.sh
+++ b/scripts/create-signing-cert.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 # One-time setup: create a self-signed code-signing certificate and export it
-# so CI can import it for stable signing.
+# so local builds can keep a stable signature across updates.
 #
 # Usage: ./scripts/create-signing-cert.sh [cert-name]
 #   cert-name defaults to "HyperPointer"
@@ -15,7 +15,8 @@
 #   Every Sparkle update changes the binary, so the hash changes, and macOS
 #   re-prompts for all permissions. A stable self-signed cert produces a
 #   requirement tied to the cert anchor hash — stable across all builds
-#   signed with the same cert.
+#   signed with the same cert. This is for local/dev use only and will not
+#   remove Gatekeeper's malware warning on other Macs.
 set -euo pipefail
 
 CERT_NAME="${1:-HyperPointer}"

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,110 @@
+#!/bin/zsh
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+TARGET_PATH=""
+APPLE_ID="${APPLE_ID:-}"
+TEAM_ID="${APPLE_TEAM_ID:-${TEAM_ID:-}}"
+PASSWORD="${APPLE_APP_SPECIFIC_PASSWORD:-${PASSWORD:-}}"
+KEYCHAIN_PROFILE="${NOTARYTOOL_KEYCHAIN_PROFILE:-${KEYCHAIN_PROFILE:-}}"
+TEMP_DIR=""
+
+cleanup() {
+  if [[ -n "$TEMP_DIR" && -d "$TEMP_DIR" ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME --path <artifact> [options]
+
+Options:
+  --path <artifact>                Path to the app or DMG to notarize
+  --apple-id <email>              Apple ID used for notarization
+  --team-id <team-id>             Apple Developer Team ID
+  --password <app-password>       Apple app-specific password
+  --keychain-profile <profile>    notarytool keychain profile to use instead
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path)
+      TARGET_PATH="${2:?missing value for --path}"
+      shift 2
+      ;;
+    --apple-id)
+      APPLE_ID="${2:?missing value for --apple-id}"
+      shift 2
+      ;;
+    --team-id)
+      TEAM_ID="${2:?missing value for --team-id}"
+      shift 2
+      ;;
+    --password)
+      PASSWORD="${2:?missing value for --password}"
+      shift 2
+      ;;
+    --keychain-profile)
+      KEYCHAIN_PROFILE="${2:?missing value for --keychain-profile}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TARGET_PATH" ]]; then
+  echo "--path is required." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -e "$TARGET_PATH" ]]; then
+  echo "Artifact does not exist: $TARGET_PATH" >&2
+  exit 1
+fi
+
+submit_target="$TARGET_PATH"
+
+if [[ -d "$TARGET_PATH" && "$TARGET_PATH" == *.app ]]; then
+  TEMP_DIR="$(mktemp -d)"
+  submit_target="$TEMP_DIR/$(basename "$TARGET_PATH").zip"
+
+  echo "Creating notarization archive: $submit_target"
+  ditto -c -k --keepParent --sequesterRsrc "$TARGET_PATH" "$submit_target"
+fi
+
+submit_args=("$submit_target" --wait)
+
+if [[ -n "$KEYCHAIN_PROFILE" ]]; then
+  submit_args+=(--keychain-profile "$KEYCHAIN_PROFILE")
+else
+  if [[ -z "$APPLE_ID" || -z "$TEAM_ID" || -z "$PASSWORD" ]]; then
+    echo "Provide either --keychain-profile or all of --apple-id, --team-id, and --password." >&2
+    exit 1
+  fi
+  submit_args+=(
+    --apple-id "$APPLE_ID"
+    --team-id "$TEAM_ID"
+    --password "$PASSWORD"
+  )
+fi
+
+echo "Submitting for notarization: $submit_target"
+xcrun notarytool submit "${submit_args[@]}"
+
+echo "Stapling ticket: $TARGET_PATH"
+xcrun stapler staple -v "$TARGET_PATH"
+
+echo "Validating stapled ticket: $TARGET_PATH"
+xcrun stapler validate -v "$TARGET_PATH"


### PR DESCRIPTION
## Summary

- Replaces the ad-hoc/self-signed certificate fallback in CI with a hard requirement for a real `Developer ID Application` certificate, so distributed builds pass Gatekeeper without the malware warning
- Adds `scripts/notarize.sh` and splits app/DMG notarization into discrete steps in the release workflow
- Adds a `developer-id` sign mode to `build-app.sh` and `build-dmg.sh` that enables hardened runtime and timestamps, and validates the entitlements file before signing
- Adds `config/macos/distribution.entitlements` for the distributable build
- Updates docs (`README.md`, checklist) to reflect the new workflow and required GitHub secrets

## Test plan

- [ ] Verify release workflow fails loudly when `DEVELOPER_ID_APPLICATION_*` secrets are missing
- [ ] Confirm `build-app.sh --sign-mode developer-id` rejects non-Developer-ID identities
- [ ] Once secrets are configured, run a release from `main` and verify the downloaded DMG opens with the normal internet-download prompt instead of the malware block

🤖 Generated with [Claude Code](https://claude.com/claude-code)