### PR TITLE
fix: use file timestamps in install fingerprint to detect reinstalls

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -447,10 +447,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private func currentOnboardingInstallIdentifier() -> String {
         let bundleURL = Bundle.main.bundleURL.resolvingSymlinksInPath()
         if bundleURL.pathExtension == "app" {
-            return bundleURL.path
+            return installFingerprint(for: bundleURL)
         }
 
-        return (Bundle.main.executableURL ?? bundleURL).resolvingSymlinksInPath().path
+        let executableURL = (Bundle.main.executableURL ?? bundleURL).resolvingSymlinksInPath()
+        return installFingerprint(for: executableURL)
+    }
+
+    private func installFingerprint(for url: URL) -> String {
+        guard let resourceValues = try? url.resourceValues(forKeys: [.creationDateKey, .contentModificationDateKey]) else {
+            return url.path
+        }
+
+        let creationTimestamp = resourceValues.creationDate?.timeIntervalSinceReferenceDate ?? 0
+        let modificationTimestamp = resourceValues.contentModificationDate?.timeIntervalSinceReferenceDate ?? 0
+        return "\(url.path)#\(creationTimestamp)#\(modificationTimestamp)"
     }
 
     func openSettingsFromCommandMenu() {


### PR DESCRIPTION
## Summary

- `currentOnboardingInstallIdentifier()` previously returned only the bundle/executable path, so a fresh reinstall at the same path would reuse the same identifier and skip onboarding
- Adds `installFingerprint(for:)` which appends the file's creation and modification timestamps to the path, making the identifier unique per install even if the path is the same
- Falls back to path-only if filesystem resource values are unavailable

## Test plan

- [ ] Fresh install shows onboarding
- [ ] Reinstall at same path shows onboarding again
- [ ] Upgrade (same bundle, no reinstall) does not re-show onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)