### PR TITLE
fix: remove non-essential permissions from onboarding and settings UI

### DIFF
--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -228,51 +228,8 @@ private struct PermissionsStep: View {
                     }
                 )
 
-                Divider()
-                    .padding(.leading, 64)
 
-                PermissionStatusRow(
-                    title: "Calendars",
-                    description: "Allow HyperPointer to read or create calendar events when needed.",
-                    icon: "calendar",
-                    state: permissionState(
-                        isGranted: viewModel.isCalendarsGranted,
-                        isBusy: viewModel.isCalendarsRequestInFlight
-                    ) {
-                        if !viewModel.isCalendarsGranted {
-                            viewModel.requestCalendars(resumeDestination: .onboarding)
-                        }
-                    }
-                )
 
-                Divider()
-                    .padding(.leading, 64)
-
-                PermissionStatusRow(
-                    title: "Contacts",
-                    description: "Allow contact lookup and people-related assistance when needed.",
-                    icon: "person.2",
-                    state: permissionState(
-                        isGranted: viewModel.isContactsGranted,
-                        isBusy: viewModel.isContactsRequestInFlight
-                    ) {
-                        if !viewModel.isContactsGranted {
-                            viewModel.requestContacts(resumeDestination: .onboarding)
-                        }
-                    }
-                )
-
-                Divider()
-                    .padding(.leading, 64)
-
-                PermissionStatusRow(
-                    title: "Full Disk Access",
-                    description: "Allow access to protected files and folders when tasks require it.",
-                    icon: "externaldrive.badge.shield.half.filled",
-                    state: .action("Grant") {
-                        viewModel.openFullDiskAccessSettings()
-                    }
-                )
 
                 Divider()
                     .padding(.leading, 64)
@@ -288,18 +245,6 @@ private struct PermissionsStep: View {
                         if !viewModel.isRemindersGranted {
                             viewModel.requestReminders(resumeDestination: .onboarding)
                         }
-                    }
-                )
-
-                Divider()
-                    .padding(.leading, 64)
-
-                PermissionStatusRow(
-                    title: "App Management",
-                    description: "Allow HyperPointer to manage other apps through macOS controls when needed.",
-                    icon: "square.stack.3d.up",
-                    state: .action("Grant") {
-                        viewModel.openAppManagementSettings()
                     }
                 )
 

--- a/Sources/OnboardingViewModel.swift
+++ b/Sources/OnboardingViewModel.swift
@@ -207,26 +207,21 @@ final class OnboardingViewModel: ObservableObject {
         guard !isMicrophoneRequestInFlight else { return }
         if prepareAppBundleForSensitivePermissionIfNeeded(.microphone, resumeDestination: resumeDestination) { return }
 
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .authorized:
+        if AVCaptureDevice.authorizationStatus(for: .audio) == .authorized {
             refreshPermissionState()
             return
-        case .denied, .restricted:
-            openMicrophoneSettings()
-            return
-        case .notDetermined:
-            break
-        @unknown default:
-            break
         }
 
         isMicrophoneRequestInFlight = true
         NSApp.activate(ignoringOtherApps: true)
 
-        AVCaptureDevice.requestAccess(for: .audio) { _ in
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
             DispatchQueue.main.async {
                 self.isMicrophoneRequestInFlight = false
                 self.refreshPermissionState()
+                if !granted {
+                    self.openMicrophoneSettings()
+                }
             }
         }
     }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -433,49 +433,6 @@ private struct PermissionsSettingsPane: View {
                     divider
 
                     SettingsPermissionStatusRow(
-                        title: "Calendars",
-                        description: "Allow HyperPointer to read or create calendar events when needed.",
-                        icon: "calendar",
-                        state: permissionState(
-                            isGranted: viewModel.isCalendarsGranted,
-                            isBusy: viewModel.isCalendarsRequestInFlight
-                        ) {
-                            if !viewModel.isCalendarsGranted {
-                                viewModel.requestCalendars(resumeDestination: .settingsPermissions)
-                            }
-                        }
-                    )
-
-                    divider
-
-                    SettingsPermissionStatusRow(
-                        title: "Contacts",
-                        description: "Allow contact lookup and people-related assistance when needed.",
-                        icon: "person.2",
-                        state: permissionState(
-                            isGranted: viewModel.isContactsGranted,
-                            isBusy: viewModel.isContactsRequestInFlight
-                        ) {
-                            if !viewModel.isContactsGranted {
-                                viewModel.requestContacts(resumeDestination: .settingsPermissions)
-                            }
-                        }
-                    )
-
-                    divider
-
-                    SettingsPermissionStatusRow(
-                        title: "Full Disk Access",
-                        description: "Allow access to protected files and folders when tasks require it.",
-                        icon: "externaldrive.badge.shield.half.filled",
-                        state: .action("Grant") {
-                            viewModel.openFullDiskAccessSettings()
-                        }
-                    )
-
-                    divider
-
-                    SettingsPermissionStatusRow(
                         title: "Reminders",
                         description: "Allow HyperPointer to read or create reminders when needed.",
                         icon: "checklist",
@@ -486,17 +443,6 @@ private struct PermissionsSettingsPane: View {
                             if !viewModel.isRemindersGranted {
                                 viewModel.requestReminders(resumeDestination: .settingsPermissions)
                             }
-                        }
-                    )
-
-                    divider
-
-                    SettingsPermissionStatusRow(
-                        title: "App Management",
-                        description: "Allow HyperPointer to manage other apps through macOS controls when needed.",
-                        icon: "square.stack.3d.up",
-                        state: .action("Grant") {
-                            viewModel.openAppManagementSettings()
                         }
                     )
 


### PR DESCRIPTION
## Summary

- Remove Calendars, Contacts, Full Disk Access, and App Management permission rows from both the onboarding permissions step and the Settings permissions pane
- Keep only core permissions: Accessibility, Screen Recording, Microphone, Speech Recognition, Reminders, and Input Monitoring
- Fix microphone permission request to open System Settings when the user denies the prompt

## Test plan

- [ ] Run through onboarding and verify only the 6 core permissions appear on the Permissions step
- [ ] Open Settings > Permissions and verify the same 6 rows appear (no Calendars, Contacts, Full Disk Access, App Management)
- [ ] Deny microphone permission when prompted and verify System Settings opens automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)