### PR TITLE
fix: show native mic permission dialog instead of opening Settings

### DIFF
--- a/Sources/OnboardingViewModel.swift
+++ b/Sources/OnboardingViewModel.swift
@@ -207,15 +207,23 @@ final class OnboardingViewModel: ObservableObject {
         guard !isMicrophoneRequestInFlight else { return }
         if prepareAppBundleForSensitivePermissionIfNeeded(.microphone, resumeDestination: resumeDestination) { return }
 
-        if AVCaptureDevice.authorizationStatus(for: .audio) == .authorized {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
             refreshPermissionState()
             return
+        case .denied, .restricted:
+            openMicrophoneSettings()
+            return
+        case .notDetermined:
+            break
+        @unknown default:
+            break
         }
 
         isMicrophoneRequestInFlight = true
         NSApp.activate(ignoringOtherApps: true)
 
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
+        AVAudioApplication.requestRecordPermission { granted in
             DispatchQueue.main.async {
                 self.isMicrophoneRequestInFlight = false
                 self.refreshPermissionState()

--- a/Sources/VoiceDictationController.swift
+++ b/Sources/VoiceDictationController.swift
@@ -79,7 +79,7 @@ final class VoiceDictationController {
     }
 
     private func requestPermissions(completion: @escaping (Bool) -> Void) {
-        AVCaptureDevice.requestAccess(for: .audio) { microphoneGranted in
+        AVAudioApplication.requestRecordPermission { microphoneGranted in
             guard microphoneGranted else {
                 completion(false)
                 return


### PR DESCRIPTION
## Summary
- Replace `AVCaptureDevice.requestAccess(for: .audio)` with `AVAudioApplication.requestRecordPermission()` in both `OnboardingViewModel` and `VoiceDictationController`, which properly triggers the native macOS permission popup
- Add explicit authorization status checking in `requestMicrophone()` to go straight to System Settings only when permission is already denied/restricted, mirroring how speech recognition handles it

## Test plan
- [ ] Reset microphone permission for HyperPointer (`tccutil reset Microphone <bundle-id>`)
- [ ] Trigger microphone permission request from onboarding — verify native popup appears
- [ ] Verify denied permission opens System Settings directly
- [ ] Verify voice dictation still works after granting permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)