### PR TITLE
Add YouTube video and repo link to onboarding welcome step

### DIFF
--- a/Sources/OnboardingView.swift
+++ b/Sources/OnboardingView.swift
@@ -87,6 +87,18 @@ private struct WelcomeStep: View {
             title: "Welcome to This",
             subtitle: "\"This\" is a powerful local assistant that reads context from your Mac and helps you act on what is on screen."
         ) {
+            YouTubeThumbnailLink(videoID: "e7nriIU9bM8")
+
+            HStack(spacing: 6) {
+                Image(systemName: "link")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Link("github.com/jasPreMar/this", destination: URL(string: "https://github.com/jasPreMar/this")!)
+                    .font(.system(size: 14, weight: .medium))
+                    .onboardingClickableCursor()
+            }
+            .padding(.top, 4)
+
             SecurityNoticeCard(
                 title: "Security notice",
                 message: "The connected AI agent can trigger powerful actions on your Mac, including running commands, reading and writing files, and capturing screenshots depending on the permissions you grant.\n\nOnly enable \"This\" if you understand the risks and trust the prompts and integrations you use."
@@ -619,6 +631,59 @@ private extension View {
             } else {
                 NSCursor.pop()
             }
+        }
+    }
+}
+
+private struct YouTubeThumbnailLink: View {
+    let videoID: String
+    @State private var thumbnailImage: NSImage?
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            let url = URL(string: "https://www.youtube.com/watch?v=\(videoID)")!
+            NSWorkspace.shared.open(url)
+        } label: {
+            ZStack {
+                if let thumbnailImage {
+                    Image(nsImage: thumbnailImage)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 314)
+                        .clipped()
+                } else {
+                    Color.black
+                        .frame(height: 314)
+                }
+
+                Color.black.opacity(isHovered ? 0.15 : 0)
+
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 60, height: 60)
+                    .overlay(
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 24))
+                            .foregroundStyle(.white)
+                            .offset(x: 2)
+                    )
+                    .shadow(color: .black.opacity(0.4), radius: 8, y: 4)
+                    .scaleEffect(isHovered ? 1.08 : 1.0)
+                    .animation(.easeInOut(duration: 0.15), value: isHovered)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .shadow(color: Color.black.opacity(0.1), radius: 16, y: 6)
+        }
+        .buttonStyle(.plain)
+        .onboardingClickableCursor()
+        .onHover { isHovered = $0 }
+        .task {
+            guard let url = URL(string: "https://img.youtube.com/vi/\(videoID)/maxresdefault.jpg"),
+                  let (data, _) = try? await URLSession.shared.data(from: url),
+                  let image = NSImage(data: data) else { return }
+            thumbnailImage = image
         }
     }
 }

--- a/Sources/SearchViewModel.swift
+++ b/Sources/SearchViewModel.swift
@@ -1164,7 +1164,7 @@ class SearchViewModel: ObservableObject {
                     return icon
                 }
             }
-            current = axValue(el, key: kAXParentAttribute) as? AXUIElement
+            current = axValue(el, key: kAXParentAttribute) as! AXUIElement?
         }
         return nil
     }


### PR DESCRIPTION
## Summary
- Adds a clickable YouTube video thumbnail to the first onboarding step that opens the video in the user's browser, with async-loaded high-res thumbnail and hover animation on the play button
- Adds a GitHub repo link (github.com/jasPreMar/this) below the video thumbnail
- Fixes a build error in SearchViewModel from a conditional downcast to CoreFoundation type `AXUIElement`

## Test plan
- [ ] Run `make run` and verify the onboarding welcome step shows the video thumbnail and repo link
- [ ] Click the video thumbnail and verify it opens YouTube in the default browser
- [ ] Click the repo link and verify it opens the GitHub page
- [ ] Verify `swift run ThisTests` passes (102 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)